### PR TITLE
[feat] 지도 클릭 기반 장소조회(nearest) 및 검색 연동 구현 (#25)

### DIFF
--- a/src/apis/placeApi.js
+++ b/src/apis/placeApi.js
@@ -54,8 +54,11 @@ async function getJson(path, options = {}) {
 
   try {
     data = await response.json()
-  } catch {
-    // 응답 본문이 없는 경우를 고려해 파싱 오류를 무시합니다.
+  } catch (error) {
+    const isNoContentResponse = response.status === 204 || response.status === 205
+    if (!isNoContentResponse && response.ok) {
+      throw new Error('서버 응답을 해석하지 못했습니다.', { cause: error })
+    }
   }
 
   if (!response.ok || data?.isSuccess === false) {

--- a/src/apis/placeApi.js
+++ b/src/apis/placeApi.js
@@ -111,8 +111,27 @@ export async function getNearestPlace({ lat, lng, radius = 30 }) {
   return { place: data.result, code: data?.code }
 }
 
-export async function searchPlaces(keyword) {
-  const query = new URLSearchParams({ q: keyword }).toString()
+export async function searchPlaces({ keyword, lat, lng, radius = 3000 }) {
+  if (!keyword?.trim()) return []
+
+  if (!isFiniteNumber(lat) || !isFiniteNumber(lng)) {
+    const error = new Error('현재 위치 정보를 확인할 수 없습니다.')
+    error.code = 'PLACE400_1'
+    throw error
+  }
+
+  if (!isFiniteNumber(radius) || radius <= 0) {
+    const error = new Error('반경 정보가 올바르지 않습니다.')
+    error.code = 'PLACE400_2'
+    throw error
+  }
+
+  const query = new URLSearchParams({
+    q: keyword.trim(),
+    lat: String(lat),
+    lng: String(lng),
+    radius: String(radius),
+  }).toString()
   const data = await getJson(`${SEARCH_PLACES_PATH}?${query}`, {
     fallbackMessage: '검색 결과를 불러오지 못했습니다.',
   })

--- a/src/apis/placeApi.js
+++ b/src/apis/placeApi.js
@@ -1,0 +1,111 @@
+import { ERROR_MESSAGE } from '../constants/errorMessages'
+import getErrorMessage from './utils/getErrorMessage'
+
+const NEAREST_PLACE_PATH = '/api/v1/places/nearest'
+const REQUEST_TIMEOUT_MS = 10000
+const NO_PLACE_CODES = new Set(['PLACE_INFO_NOT_AVAILABLE', 'PLACE200_1'])
+
+function getApiBaseUrl() {
+  const apiBaseUrl = import.meta.env.VITE_API_BASE_URL
+
+  if (!apiBaseUrl) {
+    throw new Error('VITE_API_BASE_URL 환경변수가 설정되지 않았습니다.')
+  }
+
+  return apiBaseUrl
+}
+
+function isFiniteNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+async function getJson(path, options = {}) {
+  const { fallbackMessage = ERROR_MESSAGE.DEFAULT, statusMap = {}, codeMap = {} } =
+    options
+
+  const abortController = new AbortController()
+  const timeoutId = window.setTimeout(
+    () => abortController.abort(),
+    REQUEST_TIMEOUT_MS,
+  )
+
+  let response
+
+  try {
+    response = await fetch(`${getApiBaseUrl()}${path}`, {
+      method: 'GET',
+      headers: {
+        Accept: '*/*',
+      },
+      signal: abortController.signal,
+    })
+  } catch (error) {
+    const networkMessage =
+      error?.name === 'AbortError'
+        ? ERROR_MESSAGE.TIMEOUT
+        : ERROR_MESSAGE.NETWORK
+    throw new Error(networkMessage, { cause: error })
+  } finally {
+    window.clearTimeout(timeoutId)
+  }
+
+  let data = null
+
+  try {
+    data = await response.json()
+  } catch {
+    // 응답 본문이 없는 경우를 고려해 파싱 오류를 무시합니다.
+  }
+
+  if (!response.ok || data?.isSuccess === false) {
+    const error = new Error(
+      getErrorMessage({
+        status: response.status,
+        code: data?.code,
+        message: data?.message,
+        fallbackMessage,
+        statusMap,
+        codeMap,
+      }),
+    )
+    error.status = response.status
+    error.code = data?.code
+    throw error
+  }
+
+  return data
+}
+
+export async function getNearestPlace({ lat, lng, radius = 30 }) {
+  if (!isFiniteNumber(lat) || !isFiniteNumber(lng)) {
+    const error = new Error('좌표 정보가 올바르지 않습니다.')
+    error.code = 'PLACE400_1'
+    throw error
+  }
+
+  if (!isFiniteNumber(radius) || radius <= 0) {
+    const error = new Error('반경 정보가 올바르지 않습니다.')
+    error.code = 'PLACE400_2'
+    throw error
+  }
+
+  const query = new URLSearchParams({
+    lat: String(lat),
+    lng: String(lng),
+    radius: String(radius),
+  }).toString()
+
+  const data = await getJson(`${NEAREST_PLACE_PATH}?${query}`, {
+    fallbackMessage: '장소 정보를 불러오지 못했습니다.',
+    codeMap: {
+      PLACE400_1: '좌표 정보가 올바르지 않습니다.',
+      PLACE400_2: '반경 정보가 올바르지 않습니다.',
+    },
+  })
+
+  if (NO_PLACE_CODES.has(data?.code) || data?.result == null) {
+    return { place: null, code: data?.code ?? 'PLACE_INFO_NOT_AVAILABLE' }
+  }
+
+  return { place: data.result, code: data?.code }
+}

--- a/src/apis/placeApi.js
+++ b/src/apis/placeApi.js
@@ -111,7 +111,7 @@ export async function getNearestPlace({ lat, lng, radius = 30 }) {
   return { place: data.result, code: data?.code }
 }
 
-export async function searchPlaces({ keyword, lat, lng, radius = 3000 }) {
+export async function searchPlaces({ keyword, lat, lng, radius }) {
   if (!keyword?.trim()) return []
 
   if (!isFiniteNumber(lat) || !isFiniteNumber(lng)) {
@@ -120,18 +120,23 @@ export async function searchPlaces({ keyword, lat, lng, radius = 3000 }) {
     throw error
   }
 
-  if (!isFiniteNumber(radius) || radius <= 0) {
+  if (radius !== undefined && (!isFiniteNumber(radius) || radius <= 0)) {
     const error = new Error('반경 정보가 올바르지 않습니다.')
     error.code = 'PLACE400_2'
     throw error
   }
 
-  const query = new URLSearchParams({
+  const queryParams = {
     q: keyword.trim(),
     lat: String(lat),
     lng: String(lng),
-    radius: String(radius),
-  }).toString()
+  }
+
+  if (radius !== undefined) {
+    queryParams.radius = String(radius)
+  }
+
+  const query = new URLSearchParams(queryParams).toString()
   const data = await getJson(`${SEARCH_PLACES_PATH}?${query}`, {
     fallbackMessage: '검색 결과를 불러오지 못했습니다.',
   })

--- a/src/apis/placeApi.js
+++ b/src/apis/placeApi.js
@@ -2,6 +2,7 @@ import { ERROR_MESSAGE } from '../constants/errorMessages'
 import getErrorMessage from './utils/getErrorMessage'
 
 const NEAREST_PLACE_PATH = '/api/v1/places/nearest'
+const SEARCH_PLACES_PATH = '/api/v1/places/search'
 const REQUEST_TIMEOUT_MS = 10000
 const NO_PLACE_CODES = new Set(['PLACE_INFO_NOT_AVAILABLE', 'PLACE200_1'])
 
@@ -108,4 +109,18 @@ export async function getNearestPlace({ lat, lng, radius = 30 }) {
   }
 
   return { place: data.result, code: data?.code }
+}
+
+export async function searchPlaces(keyword) {
+  const query = new URLSearchParams({ q: keyword }).toString()
+  const data = await getJson(`${SEARCH_PLACES_PATH}?${query}`, {
+    fallbackMessage: '검색 결과를 불러오지 못했습니다.',
+  })
+
+  const rawResult = data?.result
+
+  if (Array.isArray(rawResult)) return rawResult
+  if (Array.isArray(rawResult?.content)) return rawResult.content
+
+  return []
 }

--- a/src/components/Map/KakaoMapView.jsx
+++ b/src/components/Map/KakaoMapView.jsx
@@ -11,6 +11,7 @@ export default function KakaoMapView({
   pois = [],
   selectionRadiusMeters = 40,
   onPoiSelect,
+  onMapClick,
 }) {
   const appKey = import.meta.env.VITE_KAKAO_MAP_APP_KEY
   const mapRef = useRef(null)
@@ -26,6 +27,7 @@ export default function KakaoMapView({
     pois,
     selectionRadiusMeters,
     onPoiSelect,
+    onMapClick,
   })
 
   const { isLocating, geoMessage, moveToCurrentLocation } =

--- a/src/components/Map/KakaoMapView.jsx
+++ b/src/components/Map/KakaoMapView.jsx
@@ -2,6 +2,7 @@ import { useRef } from 'react'
 import useCurrentLocationOnKakaoMap from '../../hooks/map/useCurrentLocationOnKakaoMap'
 import useKakaoMapInstance from '../../hooks/map/useKakaoMapInstance'
 import usePoiSelectionOnMap from '../../hooks/map/usePoiSelectionOnMap'
+import useSingleMarkerOnMap from '../../hooks/map/useSingleMarkerOnMap'
 import CurrentLocationControl from './CurrentLocationControl'
 import { MapRoot, MapState, MapViewport } from './KakaoMapView.styles'
 
@@ -12,6 +13,7 @@ export default function KakaoMapView({
   selectionRadiusMeters = 40,
   onPoiSelect,
   onMapClick,
+  markerPosition = null,
 }) {
   const appKey = import.meta.env.VITE_KAKAO_MAP_APP_KEY
   const mapRef = useRef(null)
@@ -29,6 +31,7 @@ export default function KakaoMapView({
     onPoiSelect,
     onMapClick,
   })
+  useSingleMarkerOnMap({ map, markerPosition })
 
   const { isLocating, geoMessage, moveToCurrentLocation } =
     useCurrentLocationOnKakaoMap(map)

--- a/src/components/Map/KakaoMapView.jsx
+++ b/src/components/Map/KakaoMapView.jsx
@@ -14,6 +14,8 @@ export default function KakaoMapView({
   onPoiSelect,
   onMapClick,
   markerPosition = null,
+  markerOffsetY = 0,
+  onCurrentLocationSelect,
 }) {
   const appKey = import.meta.env.VITE_KAKAO_MAP_APP_KEY
   const mapRef = useRef(null)
@@ -31,10 +33,10 @@ export default function KakaoMapView({
     onPoiSelect,
     onMapClick,
   })
-  useSingleMarkerOnMap({ map, markerPosition })
+  useSingleMarkerOnMap({ map, markerPosition, markerOffsetY })
 
   const { isLocating, geoMessage, moveToCurrentLocation } =
-    useCurrentLocationOnKakaoMap(map)
+    useCurrentLocationOnKakaoMap(map, onCurrentLocationSelect)
 
   if (status === 'error-key') {
     return <MapState>카카오맵 키가 설정되지 않았습니다.</MapState>

--- a/src/hooks/map/useCurrentLocationOnKakaoMap.js
+++ b/src/hooks/map/useCurrentLocationOnKakaoMap.js
@@ -1,8 +1,7 @@
-import { useCallback, useRef } from 'react'
+import { useCallback } from 'react'
 import useCurrentLocation from '../useCurrentLocation'
 
-export default function useCurrentLocationOnKakaoMap(map) {
-  const currentMarkerRef = useRef(null)
+export default function useCurrentLocationOnKakaoMap(map, onLocated) {
   const { isLocating, geoMessage, requestCurrentLocation } = useCurrentLocation()
 
   const moveToCurrentLocation = useCallback(() => {
@@ -13,19 +12,10 @@ export default function useCurrentLocationOnKakaoMap(map) {
         const target = new window.kakao.maps.LatLng(latitude, longitude)
 
         map.panTo(target)
-
-        if (currentMarkerRef.current) {
-          currentMarkerRef.current.setPosition(target)
-          return
-        }
-
-        currentMarkerRef.current = new window.kakao.maps.Marker({
-          map,
-          position: target,
-        })
+        onLocated?.({ lat: latitude, lng: longitude })
       },
     })
-  }, [map, requestCurrentLocation])
+  }, [map, onLocated, requestCurrentLocation])
 
   return {
     isLocating,

--- a/src/hooks/map/usePoiSelectionOnMap.js
+++ b/src/hooks/map/usePoiSelectionOnMap.js
@@ -6,6 +6,7 @@ export default function usePoiSelectionOnMap({
   pois,
   selectionRadiusMeters,
   onPoiSelect,
+  onMapClick,
 }) {
   const selectedPoiMarkerRef = useRef(null)
 
@@ -13,13 +14,15 @@ export default function usePoiSelectionOnMap({
     if (!map || !window.kakao?.maps?.event) return
 
     const handleMapClick = (mouseEvent) => {
-      if (!pois.length) return
-
       const clickLatLng = mouseEvent.latLng
       const clickPoint = {
         lat: clickLatLng.getLat(),
         lng: clickLatLng.getLng(),
       }
+      onMapClick?.(clickPoint)
+
+      if (!pois.length) return
+
       const selectedPoi = findNearestPoiWithinRadius(
         clickPoint,
         pois,
@@ -55,5 +58,5 @@ export default function usePoiSelectionOnMap({
         window.kakao.maps.event.removeListener(map, 'click', handleMapClick)
       }
     }
-  }, [map, onPoiSelect, pois, selectionRadiusMeters])
+  }, [map, onMapClick, onPoiSelect, pois, selectionRadiusMeters])
 }

--- a/src/hooks/map/usePoiSelectionOnMap.js
+++ b/src/hooks/map/usePoiSelectionOnMap.js
@@ -19,7 +19,15 @@ export default function usePoiSelectionOnMap({
         lat: clickLatLng.getLat(),
         lng: clickLatLng.getLng(),
       }
-      onMapClick?.(clickPoint)
+      if (onMapClick) {
+        if (selectedPoiMarkerRef.current) {
+          selectedPoiMarkerRef.current.setMap(null)
+          selectedPoiMarkerRef.current = null
+        }
+        onPoiSelect?.(null)
+        onMapClick(clickPoint)
+        return
+      }
 
       if (!pois.length) return
 

--- a/src/hooks/map/useSingleMarkerOnMap.js
+++ b/src/hooks/map/useSingleMarkerOnMap.js
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from 'react'
+
+export default function useSingleMarkerOnMap({ map, markerPosition }) {
+  const markerRef = useRef(null)
+
+  useEffect(() => {
+    if (!map || !window.kakao?.maps) return
+
+    if (!markerPosition) {
+      if (markerRef.current) {
+        markerRef.current.setMap(null)
+        markerRef.current = null
+      }
+      return
+    }
+
+    const target = new window.kakao.maps.LatLng(
+      markerPosition.lat,
+      markerPosition.lng,
+    )
+
+    if (markerRef.current) {
+      markerRef.current.setPosition(target)
+      return
+    }
+
+    markerRef.current = new window.kakao.maps.Marker({
+      map,
+      position: target,
+    })
+  }, [map, markerPosition])
+}
+

--- a/src/hooks/map/useSingleMarkerOnMap.js
+++ b/src/hooks/map/useSingleMarkerOnMap.js
@@ -7,6 +7,8 @@ export default function useSingleMarkerOnMap({
 }) {
   const markerRef = useRef(null)
   const lastAdjustedKeyRef = useRef('')
+  const markerMapRef = useRef(null)
+  const panTimerRef = useRef(null)
 
   useEffect(() => {
     if (!map || !window.kakao?.maps) return
@@ -16,7 +18,12 @@ export default function useSingleMarkerOnMap({
         markerRef.current.setMap(null)
         markerRef.current = null
       }
+      markerMapRef.current = null
       lastAdjustedKeyRef.current = ''
+      if (panTimerRef.current) {
+        window.clearTimeout(panTimerRef.current)
+        panTimerRef.current = null
+      }
       return
     }
 
@@ -26,6 +33,9 @@ export default function useSingleMarkerOnMap({
     )
 
     if (markerRef.current) {
+      if (markerMapRef.current !== map) {
+        markerRef.current.setMap(map)
+      }
       markerRef.current.setPosition(target)
     } else {
       markerRef.current = new window.kakao.maps.Marker({
@@ -33,6 +43,7 @@ export default function useSingleMarkerOnMap({
         position: target,
       })
     }
+    markerMapRef.current = map
 
     markerRef.current.setZIndex(10)
 
@@ -43,8 +54,19 @@ export default function useSingleMarkerOnMap({
     lastAdjustedKeyRef.current = markerKey
 
     map.panTo(target)
-    window.setTimeout(() => {
+    if (panTimerRef.current) {
+      window.clearTimeout(panTimerRef.current)
+    }
+    panTimerRef.current = window.setTimeout(() => {
       map.panBy(0, markerOffsetY)
+      panTimerRef.current = null
     }, 0)
+
+    return () => {
+      if (panTimerRef.current) {
+        window.clearTimeout(panTimerRef.current)
+        panTimerRef.current = null
+      }
+    }
   }, [map, markerOffsetY, markerPosition])
 }

--- a/src/hooks/map/useSingleMarkerOnMap.js
+++ b/src/hooks/map/useSingleMarkerOnMap.js
@@ -1,7 +1,12 @@
 import { useEffect, useRef } from 'react'
 
-export default function useSingleMarkerOnMap({ map, markerPosition }) {
+export default function useSingleMarkerOnMap({
+  map,
+  markerPosition,
+  markerOffsetY = 0,
+}) {
   const markerRef = useRef(null)
+  const lastAdjustedKeyRef = useRef('')
 
   useEffect(() => {
     if (!map || !window.kakao?.maps) return
@@ -11,6 +16,7 @@ export default function useSingleMarkerOnMap({ map, markerPosition }) {
         markerRef.current.setMap(null)
         markerRef.current = null
       }
+      lastAdjustedKeyRef.current = ''
       return
     }
 
@@ -21,13 +27,24 @@ export default function useSingleMarkerOnMap({ map, markerPosition }) {
 
     if (markerRef.current) {
       markerRef.current.setPosition(target)
-      return
+    } else {
+      markerRef.current = new window.kakao.maps.Marker({
+        map,
+        position: target,
+      })
     }
 
-    markerRef.current = new window.kakao.maps.Marker({
-      map,
-      position: target,
-    })
-  }, [map, markerPosition])
-}
+    markerRef.current.setZIndex(10)
 
+    if (!markerOffsetY) return
+
+    const markerKey = `${markerPosition.lat}:${markerPosition.lng}:${markerOffsetY}`
+    if (lastAdjustedKeyRef.current === markerKey) return
+    lastAdjustedKeyRef.current = markerKey
+
+    map.panTo(target)
+    window.setTimeout(() => {
+      map.panBy(0, markerOffsetY)
+    }, 0)
+  }, [map, markerOffsetY, markerPosition])
+}

--- a/src/mocks/search/searchPage.mock.js
+++ b/src/mocks/search/searchPage.mock.js
@@ -3,8 +3,8 @@ export const mockAutocompleteKeywords = ['공학관', '중앙도서관', '학생
 export const mockSearchPlaces = [
   {
     id: 'place-1',
-    title: '공학관',
-    address: '서울시 관악구 관악로 1',
+    title: '동국대학교 신공학관',
+    address: '서울시 중구 필동로 1길 30',
     isRegistered: true,
   },
   {

--- a/src/pages/MapPage/MapPage.css
+++ b/src/pages/MapPage/MapPage.css
@@ -15,3 +15,19 @@
   right: var(--space-16);
   z-index: 10;
 }
+
+.map-page__notice {
+  position: absolute;
+  top: calc(var(--space-16) + var(--size-48) + var(--space-8));
+  left: var(--space-16);
+  right: var(--space-16);
+  margin: 0;
+  padding: var(--space-10) var(--space-12);
+  border-radius: var(--radius-10);
+  background: rgba(10, 10, 10, 0.85);
+  color: var(--text-inverse);
+  font-family: var(--font-sans);
+  font-size: var(--text-14);
+  line-height: var(--line-20);
+  z-index: 10;
+}

--- a/src/pages/MapPage/MapPage.jsx
+++ b/src/pages/MapPage/MapPage.jsx
@@ -1,5 +1,6 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
+import { getNearestPlace } from '../../apis/placeApi'
 import BottomNav from '../../components/BottomNav/BottomNav'
 import KakaoMapView from '../../components/Map/KakaoMapView'
 import MapPoiSheet from '../../components/Map/MapPoiSheet'
@@ -10,22 +11,67 @@ import isRegisteredPlace from '../../utils/map/isRegisteredPlace'
 import { resolvePoiFromSearch } from '../../utils/map/searchPoiResolver'
 import './MapPage.css'
 
+const NEAREST_RADIUS_METERS = 30
+const NOTICE_TIMEOUT_MS = 2400
+const NO_PLACE_CODE = 'PLACE_INFO_NOT_AVAILABLE'
+
+function mapNearestPlaceToPoi(place) {
+  return {
+    id:
+      place.externalApiId ??
+      place.id ??
+      `${place.name ?? place.placeName ?? 'place'}-${place.lat}-${place.lng}`,
+    name: place.name ?? place.placeName ?? place.title ?? '장소명',
+    address: place.roadAddress || place.address || '주소 정보 없음',
+    lat: place.lat,
+    lng: place.lng,
+    isRegistered: Boolean(place.isRegistered),
+    externalApiId: place.externalApiId,
+  }
+}
+
 export default function MapPage() {
   const location = useLocation()
   const navigate = useNavigate()
   const selectedSearchPlace = location.state?.selectedSearchPlace
   const [currentNav, setCurrentNav] = useState('map')
+  const [mapNotice, setMapNotice] = useState('')
   const [selectedPoi, setSelectedPoi] = useState(() =>
     resolvePoiFromSearch(selectedSearchPlace, mockMapPois),
   )
+  const requestSeqRef = useRef(0)
+  const noticeTimerRef = useRef(null)
   const registeredPlaces = useMemo(
     () => mockSearchPlaces.filter((place) => place.isRegistered),
     [],
   )
   const isSelectedPoiRegistered = useMemo(
-    () => isRegisteredPlace(selectedPoi, registeredPlaces),
+    () =>
+      typeof selectedPoi?.isRegistered === 'boolean'
+        ? selectedPoi.isRegistered
+        : isRegisteredPlace(selectedPoi, registeredPlaces),
     [registeredPlaces, selectedPoi],
   )
+
+  useEffect(() => {
+    return () => {
+      if (noticeTimerRef.current) {
+        window.clearTimeout(noticeTimerRef.current)
+      }
+    }
+  }, [])
+
+  const showMapNotice = (message) => {
+    setMapNotice(message)
+
+    if (noticeTimerRef.current) {
+      window.clearTimeout(noticeTimerRef.current)
+    }
+
+    noticeTimerRef.current = window.setTimeout(() => {
+      setMapNotice('')
+    }, NOTICE_TIMEOUT_MS)
+  }
 
   const closePoiSheet = () => {
     setSelectedPoi(null)
@@ -42,10 +88,39 @@ export default function MapPage() {
     }
   }
 
+  const handleMapClick = async ({ lat, lng }) => {
+    const requestId = ++requestSeqRef.current
+
+    try {
+      const { place, code } = await getNearestPlace({
+        lat,
+        lng,
+        radius: NEAREST_RADIUS_METERS,
+      })
+
+      if (requestId !== requestSeqRef.current) return
+
+      if (!place) {
+        setSelectedPoi(null)
+        if (code === NO_PLACE_CODE || code === 'PLACE200_1') {
+          showMapNotice('해당 위치의 장소 정보를 찾을 수 없어요.')
+        }
+        return
+      }
+
+      setMapNotice('')
+      setSelectedPoi(mapNearestPlaceToPoi(place))
+    } catch (error) {
+      if (requestId !== requestSeqRef.current) return
+      setSelectedPoi(null)
+      showMapNotice(error?.message ?? '장소 정보를 불러오지 못했습니다.')
+    }
+  }
+
   return (
     <main className="map-page">
       <div className="map-page__viewport">
-        <KakaoMapView pois={mockMapPois} onPoiSelect={setSelectedPoi} />
+        <KakaoMapView pois={[]} onMapClick={handleMapClick} />
       </div>
 
       <div className="map-page__search">
@@ -57,6 +132,7 @@ export default function MapPage() {
           onKeyDown={handleSearchInputKeyDown}
         />
       </div>
+      {mapNotice ? <p className="map-page__notice">{mapNotice}</p> : null}
 
       <BottomNav currentKey={currentNav} onChange={setCurrentNav} />
 

--- a/src/pages/MapPage/MapPage.jsx
+++ b/src/pages/MapPage/MapPage.jsx
@@ -5,10 +5,8 @@ import BottomNav from '../../components/BottomNav/BottomNav'
 import KakaoMapView from '../../components/Map/KakaoMapView'
 import MapPoiSheet from '../../components/Map/MapPoiSheet'
 import SearchInput from '../../components/SearchInput/SearchInput'
-import { mockMapPois } from '../../mocks/map/poi.mock'
 import { mockSearchPlaces } from '../../mocks/search/searchPage.mock'
 import isRegisteredPlace from '../../utils/map/isRegisteredPlace'
-import { resolvePoiFromSearch } from '../../utils/map/searchPoiResolver'
 import './MapPage.css'
 
 const NEAREST_RADIUS_METERS = 30
@@ -38,9 +36,8 @@ export default function MapPage() {
   const [currentNav, setCurrentNav] = useState('map')
   const [mapCenter, setMapCenter] = useState(DEFAULT_MAP_CENTER)
   const [mapNotice, setMapNotice] = useState('')
-  const [selectedPoi, setSelectedPoi] = useState(() =>
-    resolvePoiFromSearch(selectedSearchPlace, mockMapPois),
-  )
+  const [selectedMarkerPosition, setSelectedMarkerPosition] = useState(null)
+  const [selectedPoi, setSelectedPoi] = useState(null)
   const requestSeqRef = useRef(0)
   const noticeTimerRef = useRef(null)
   const registeredPlaces = useMemo(
@@ -84,6 +81,11 @@ export default function MapPage() {
     )
   }, [])
 
+  useEffect(() => {
+    if (!selectedSearchPlace) return
+    navigate('/map', { replace: true, state: null })
+  }, [navigate, selectedSearchPlace])
+
   const showMapNotice = (message) => {
     setMapNotice(message)
 
@@ -98,6 +100,7 @@ export default function MapPage() {
 
   const closePoiSheet = () => {
     setSelectedPoi(null)
+    setSelectedMarkerPosition(null)
   }
 
   const openSearchPage = () => {
@@ -125,17 +128,24 @@ export default function MapPage() {
 
       if (!place) {
         setSelectedPoi(null)
+        setSelectedMarkerPosition(null)
         if (code === NO_PLACE_CODE || code === 'PLACE200_1') {
           showMapNotice('해당 위치의 장소 정보를 찾을 수 없어요.')
         }
         return
       }
 
+      const mappedPoi = mapNearestPlaceToPoi(place)
       setMapNotice('')
-      setSelectedPoi(mapNearestPlaceToPoi(place))
+      setSelectedPoi(mappedPoi)
+      setSelectedMarkerPosition({
+        lat: mappedPoi.lat,
+        lng: mappedPoi.lng,
+      })
     } catch (error) {
       if (requestId !== requestSeqRef.current) return
       setSelectedPoi(null)
+      setSelectedMarkerPosition(null)
       showMapNotice(error?.message ?? '장소 정보를 불러오지 못했습니다.')
     }
   }
@@ -143,7 +153,12 @@ export default function MapPage() {
   return (
     <main className="map-page">
       <div className="map-page__viewport">
-        <KakaoMapView center={mapCenter} pois={[]} onMapClick={handleMapClick} />
+        <KakaoMapView
+          center={mapCenter}
+          pois={[]}
+          markerPosition={selectedMarkerPosition}
+          onMapClick={handleMapClick}
+        />
       </div>
 
       <div className="map-page__search">

--- a/src/pages/MapPage/MapPage.jsx
+++ b/src/pages/MapPage/MapPage.jsx
@@ -14,6 +14,7 @@ import './MapPage.css'
 const NEAREST_RADIUS_METERS = 30
 const NOTICE_TIMEOUT_MS = 2400
 const NO_PLACE_CODE = 'PLACE_INFO_NOT_AVAILABLE'
+const DEFAULT_MAP_CENTER = { lat: 37.558107, lng: 126.998945 }
 
 function mapNearestPlaceToPoi(place) {
   return {
@@ -35,6 +36,7 @@ export default function MapPage() {
   const navigate = useNavigate()
   const selectedSearchPlace = location.state?.selectedSearchPlace
   const [currentNav, setCurrentNav] = useState('map')
+  const [mapCenter, setMapCenter] = useState(DEFAULT_MAP_CENTER)
   const [mapNotice, setMapNotice] = useState('')
   const [selectedPoi, setSelectedPoi] = useState(() =>
     resolvePoiFromSearch(selectedSearchPlace, mockMapPois),
@@ -59,6 +61,27 @@ export default function MapPage() {
         window.clearTimeout(noticeTimerRef.current)
       }
     }
+  }, [])
+
+  useEffect(() => {
+    if (!navigator.geolocation) return
+
+    navigator.geolocation.getCurrentPosition(
+      ({ coords }) => {
+        setMapCenter({
+          lat: coords.latitude,
+          lng: coords.longitude,
+        })
+      },
+      () => {
+        // 권한 거부/실패 시 기본 중심 좌표(동국대)를 유지합니다.
+      },
+      {
+        enableHighAccuracy: true,
+        timeout: 10000,
+        maximumAge: 60000,
+      },
+    )
   }, [])
 
   const showMapNotice = (message) => {
@@ -120,7 +143,7 @@ export default function MapPage() {
   return (
     <main className="map-page">
       <div className="map-page__viewport">
-        <KakaoMapView pois={[]} onMapClick={handleMapClick} />
+        <KakaoMapView center={mapCenter} pois={[]} onMapClick={handleMapClick} />
       </div>
 
       <div className="map-page__search">

--- a/src/pages/MapPage/MapPage.jsx
+++ b/src/pages/MapPage/MapPage.jsx
@@ -5,8 +5,10 @@ import BottomNav from '../../components/BottomNav/BottomNav'
 import KakaoMapView from '../../components/Map/KakaoMapView'
 import MapPoiSheet from '../../components/Map/MapPoiSheet'
 import SearchInput from '../../components/SearchInput/SearchInput'
+import { mockMapPois } from '../../mocks/map/poi.mock'
 import { mockSearchPlaces } from '../../mocks/search/searchPage.mock'
 import isRegisteredPlace from '../../utils/map/isRegisteredPlace'
+import { resolvePoiFromSearch } from '../../utils/map/searchPoiResolver'
 import './MapPage.css'
 
 const NEAREST_RADIUS_METERS = 30
@@ -33,11 +35,28 @@ export default function MapPage() {
   const location = useLocation()
   const navigate = useNavigate()
   const selectedSearchPlace = location.state?.selectedSearchPlace
+  const shouldOpenFromSearch = location.state?.openSheetFrom === 'search-result'
+  const initialSelectedPoi =
+    shouldOpenFromSearch && selectedSearchPlace
+      ? resolvePoiFromSearch(selectedSearchPlace, mockMapPois)
+      : null
   const [currentNav, setCurrentNav] = useState('map')
-  const [mapCenter, setMapCenter] = useState(DEFAULT_MAP_CENTER)
+  const [mapCenter, setMapCenter] = useState(() =>
+    initialSelectedPoi &&
+    typeof initialSelectedPoi.lat === 'number' &&
+    typeof initialSelectedPoi.lng === 'number'
+      ? { lat: initialSelectedPoi.lat, lng: initialSelectedPoi.lng }
+      : DEFAULT_MAP_CENTER,
+  )
   const [mapNotice, setMapNotice] = useState('')
-  const [selectedMarkerPosition, setSelectedMarkerPosition] = useState(null)
-  const [selectedPoi, setSelectedPoi] = useState(null)
+  const [selectedMarkerPosition, setSelectedMarkerPosition] = useState(() =>
+    initialSelectedPoi &&
+    typeof initialSelectedPoi.lat === 'number' &&
+    typeof initialSelectedPoi.lng === 'number'
+      ? { lat: initialSelectedPoi.lat, lng: initialSelectedPoi.lng }
+      : null,
+  )
+  const [selectedPoi, setSelectedPoi] = useState(initialSelectedPoi)
   const requestSeqRef = useRef(0)
   const noticeTimerRef = useRef(null)
   const registeredPlaces = useMemo(
@@ -61,6 +80,7 @@ export default function MapPage() {
   }, [])
 
   useEffect(() => {
+    if (shouldOpenFromSearch) return
     if (!navigator.geolocation) return
 
     navigator.geolocation.getCurrentPosition(
@@ -79,7 +99,7 @@ export default function MapPage() {
         maximumAge: 60000,
       },
     )
-  }, [])
+  }, [shouldOpenFromSearch])
 
   useEffect(() => {
     if (!selectedSearchPlace) return
@@ -114,6 +134,13 @@ export default function MapPage() {
     }
   }
 
+  const handleCurrentLocationSelect = ({ lat, lng }) => {
+    setMapCenter({ lat, lng })
+    setSelectedPoi(null)
+    setSelectedMarkerPosition({ lat, lng })
+    setMapNotice('')
+  }
+
   const handleMapClick = async ({ lat, lng }) => {
     const requestId = ++requestSeqRef.current
 
@@ -138,6 +165,10 @@ export default function MapPage() {
       const mappedPoi = mapNearestPlaceToPoi(place)
       setMapNotice('')
       setSelectedPoi(mappedPoi)
+      setMapCenter({
+        lat: mappedPoi.lat,
+        lng: mappedPoi.lng,
+      })
       setSelectedMarkerPosition({
         lat: mappedPoi.lat,
         lng: mappedPoi.lng,
@@ -157,6 +188,8 @@ export default function MapPage() {
           center={mapCenter}
           pois={[]}
           markerPosition={selectedMarkerPosition}
+          markerOffsetY={selectedPoi ? -200 : 0}
+          onCurrentLocationSelect={handleCurrentLocationSelect}
           onMapClick={handleMapClick}
         />
       </div>

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -28,10 +28,20 @@ export default function SearchPage() {
   const searchTimerRef = useRef(null)
   const requestSeqRef = useRef(0)
 
+  const invalidatePendingSearch = () => {
+    requestSeqRef.current += 1
+    if (searchTimerRef.current) {
+      window.clearTimeout(searchTimerRef.current)
+      searchTimerRef.current = null
+    }
+  }
+
   useEffect(() => {
     return () => {
+      requestSeqRef.current += 1
       if (searchTimerRef.current) {
         window.clearTimeout(searchTimerRef.current)
+        searchTimerRef.current = null
       }
     }
   }, [])
@@ -70,6 +80,7 @@ export default function SearchPage() {
     const normalized = normalizeText(rawKeyword)
 
     if (!normalized) {
+      invalidatePendingSearch()
       setIsResultMode(false)
       setIsLoading(false)
       setHasSearchError(false)
@@ -79,6 +90,7 @@ export default function SearchPage() {
     }
 
     if (!searchCenter) {
+      invalidatePendingSearch()
       setIsResultMode(true)
       setIsLoading(false)
       setHasSearchError(true)
@@ -94,6 +106,7 @@ export default function SearchPage() {
 
     if (searchTimerRef.current) {
       window.clearTimeout(searchTimerRef.current)
+      searchTimerRef.current = null
     }
 
     const requestId = ++requestSeqRef.current
@@ -132,13 +145,10 @@ export default function SearchPage() {
   }
 
   const handleChangeKeyword = (nextKeyword) => {
+    invalidatePendingSearch()
     setKeyword(nextKeyword)
     setIsResultMode(false)
     setIsLoading(false)
-
-    if (searchTimerRef.current) {
-      window.clearTimeout(searchTimerRef.current)
-    }
   }
 
   const handleSelectAutocomplete = (selectedKeyword) => {

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -150,7 +150,10 @@ export default function SearchPage() {
 
   const handleSelectResult = (selectedPlace) => {
     navigate('/map', {
-      state: { selectedSearchPlace: selectedPlace },
+      state: {
+        selectedSearchPlace: selectedPlace,
+        openSheetFrom: 'search-result',
+      },
     })
   }
 

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -1,12 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { searchPlaces } from '../../apis/placeApi'
 import CommonHeader from '../../components/CommonHeader/CommonHeader'
 import SearchAutocompleteList from '../../components/Search/SearchAutocompleteList'
 import SearchResultList from '../../components/Search/SearchResultList'
-import {
-  mockAutocompleteKeywords,
-  mockSearchPlaces,
-} from '../../mocks/search/searchPage.mock'
+import { mockAutocompleteKeywords } from '../../mocks/search/searchPage.mock'
 import './SearchPage.css'
 
 const SEARCH_DELAY_MS = 250
@@ -17,8 +15,10 @@ export default function SearchPage() {
   const [keyword, setKeyword] = useState('')
   const [isResultMode, setIsResultMode] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
+  const [hasSearchError, setHasSearchError] = useState(false)
   const [resultItems, setResultItems] = useState([])
   const searchTimerRef = useRef(null)
+  const requestSeqRef = useRef(0)
 
   useEffect(() => {
     return () => {
@@ -43,25 +43,46 @@ export default function SearchPage() {
     if (!normalized) {
       setIsResultMode(false)
       setIsLoading(false)
+      setHasSearchError(false)
       setResultItems([])
       return
     }
 
     setIsResultMode(true)
     setIsLoading(true)
+    setHasSearchError(false)
 
     if (searchTimerRef.current) {
       window.clearTimeout(searchTimerRef.current)
     }
 
-    searchTimerRef.current = window.setTimeout(() => {
-      const filtered = mockSearchPlaces.filter(
-        (item) =>
-          normalizeText(item.title).includes(normalized) ||
-          normalizeText(item.address).includes(normalized),
-      )
-      setResultItems(filtered)
-      setIsLoading(false)
+    const requestId = ++requestSeqRef.current
+
+    searchTimerRef.current = window.setTimeout(async () => {
+      try {
+        const places = await searchPlaces(normalized)
+        if (requestId !== requestSeqRef.current) return
+
+        const mappedPlaces = places.map((place, idx) => ({
+          id: place.externalApiId ?? `${place.name}-${idx}`,
+          title: place.name,
+          address: place.roadAddress || place.address || '주소 정보 없음',
+          isRegistered: Boolean(place.isRegistered),
+          lat: place.lat,
+          lng: place.lng,
+          externalApiId: place.externalApiId,
+        }))
+
+        setResultItems(mappedPlaces)
+      } catch {
+        if (requestId !== requestSeqRef.current) return
+        setHasSearchError(true)
+        setResultItems([])
+      } finally {
+        if (requestId === requestSeqRef.current) {
+          setIsLoading(false)
+        }
+      }
     }, SEARCH_DELAY_MS)
   }
 
@@ -77,16 +98,6 @@ export default function SearchPage() {
 
   const handleSelectAutocomplete = (selectedKeyword) => {
     setKeyword(selectedKeyword)
-
-    const exactMatch = mockSearchPlaces.find(
-      (item) => normalizeText(item.title) === normalizeText(selectedKeyword),
-    )
-
-    if (exactMatch) {
-      handleSelectResult(exactMatch)
-      return
-    }
-
     runSearch(selectedKeyword)
   }
 
@@ -128,7 +139,11 @@ export default function SearchPage() {
         ) : null}
 
         {isResultMode && !isLoading && resultItems.length === 0 ? (
-          <p className="search-page__state">검색 결과가 없습니다.</p>
+          <p className="search-page__state">
+            {hasSearchError
+              ? '검색 결과를 불러오지 못했습니다.'
+              : '검색 결과가 없습니다.'}
+          </p>
         ) : null}
       </section>
     </main>

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -8,7 +8,6 @@ import { mockAutocompleteKeywords } from '../../mocks/search/searchPage.mock'
 import './SearchPage.css'
 
 const SEARCH_DELAY_MS = 250
-const SEARCH_RADIUS_METERS = 3000
 const normalizeText = (value = '') => value.trim().toLowerCase()
 const GEOLOCATION_UNAVAILABLE_MESSAGE = '현재 위치 정보를 사용할 수 없습니다.'
 const GEOLOCATION_REQUIRED_MESSAGE = '현재 위치를 확인한 뒤 다시 검색해 주세요.'
@@ -105,7 +104,6 @@ export default function SearchPage() {
           keyword: normalized,
           lat: searchCenter.lat,
           lng: searchCenter.lng,
-          radius: SEARCH_RADIUS_METERS,
         })
         if (requestId !== requestSeqRef.current) return
 

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -8,14 +8,23 @@ import { mockAutocompleteKeywords } from '../../mocks/search/searchPage.mock'
 import './SearchPage.css'
 
 const SEARCH_DELAY_MS = 250
+const SEARCH_RADIUS_METERS = 3000
 const normalizeText = (value = '') => value.trim().toLowerCase()
+const GEOLOCATION_UNAVAILABLE_MESSAGE = '현재 위치 정보를 사용할 수 없습니다.'
+const GEOLOCATION_REQUIRED_MESSAGE = '현재 위치를 확인한 뒤 다시 검색해 주세요.'
 
 export default function SearchPage() {
   const navigate = useNavigate()
+  const supportsGeolocation =
+    typeof navigator !== 'undefined' && 'geolocation' in navigator
   const [keyword, setKeyword] = useState('')
   const [isResultMode, setIsResultMode] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [hasSearchError, setHasSearchError] = useState(false)
+  const [searchStateMessage, setSearchStateMessage] = useState(
+    supportsGeolocation ? '' : GEOLOCATION_UNAVAILABLE_MESSAGE,
+  )
+  const [searchCenter, setSearchCenter] = useState(null)
   const [resultItems, setResultItems] = useState([])
   const searchTimerRef = useRef(null)
   const requestSeqRef = useRef(0)
@@ -27,6 +36,27 @@ export default function SearchPage() {
       }
     }
   }, [])
+
+  useEffect(() => {
+    if (!supportsGeolocation) return
+
+    navigator.geolocation.getCurrentPosition(
+      ({ coords }) => {
+        setSearchCenter({
+          lat: coords.latitude,
+          lng: coords.longitude,
+        })
+      },
+      () => {
+        setSearchStateMessage(GEOLOCATION_REQUIRED_MESSAGE)
+      },
+      {
+        enableHighAccuracy: true,
+        timeout: 10000,
+        maximumAge: 60000,
+      },
+    )
+  }, [supportsGeolocation])
 
   const autocompleteItems = useMemo(() => {
     const normalized = normalizeText(keyword)
@@ -44,6 +74,16 @@ export default function SearchPage() {
       setIsResultMode(false)
       setIsLoading(false)
       setHasSearchError(false)
+      setSearchStateMessage('')
+      setResultItems([])
+      return
+    }
+
+    if (!searchCenter) {
+      setIsResultMode(true)
+      setIsLoading(false)
+      setHasSearchError(true)
+      setSearchStateMessage(GEOLOCATION_REQUIRED_MESSAGE)
       setResultItems([])
       return
     }
@@ -51,6 +91,7 @@ export default function SearchPage() {
     setIsResultMode(true)
     setIsLoading(true)
     setHasSearchError(false)
+    setSearchStateMessage('')
 
     if (searchTimerRef.current) {
       window.clearTimeout(searchTimerRef.current)
@@ -60,7 +101,12 @@ export default function SearchPage() {
 
     searchTimerRef.current = window.setTimeout(async () => {
       try {
-        const places = await searchPlaces(normalized)
+        const places = await searchPlaces({
+          keyword: normalized,
+          lat: searchCenter.lat,
+          lng: searchCenter.lng,
+          radius: SEARCH_RADIUS_METERS,
+        })
         if (requestId !== requestSeqRef.current) return
 
         const mappedPlaces = places.map((place, idx) => ({
@@ -77,6 +123,7 @@ export default function SearchPage() {
       } catch {
         if (requestId !== requestSeqRef.current) return
         setHasSearchError(true)
+        setSearchStateMessage('검색 결과를 불러오지 못했습니다.')
         setResultItems([])
       } finally {
         if (requestId === requestSeqRef.current) {
@@ -141,7 +188,7 @@ export default function SearchPage() {
         {isResultMode && !isLoading && resultItems.length === 0 ? (
           <p className="search-page__state">
             {hasSearchError
-              ? '검색 결과를 불러오지 못했습니다.'
+              ? searchStateMessage || '검색 결과를 불러오지 못했습니다.'
               : '검색 결과가 없습니다.'}
           </p>
         ) : null}

--- a/src/utils/map/searchPoiResolver.js
+++ b/src/utils/map/searchPoiResolver.js
@@ -21,6 +21,8 @@ export function resolvePoiFromSearch(selectedSearchPlace, mapPois = []) {
     id: `search-${selectedSearchPlace.id ?? keyword}`,
     name: selectedSearchPlace.title,
     address: selectedSearchPlace.address,
+    lat: selectedSearchPlace.lat,
+    lng: selectedSearchPlace.lng,
     isRegistered: selectedSearchPlace.isRegistered,
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closed #25 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
/map 페이지에서 건물 클릭하면 해당 건물 상세 관련해서 바텀시트 나와요. (등록된 경우랑 등록되지 않은 건물 상황에 맞게 나와요)
현재 검색은 FTX도 아니가 엘라스틱 서치도 사용하지 않았어요 그건 추후에  구현할 거에요.
그리고 검색 리스트는 현재 위치 기준으로 나오고, 등록된 건물일 경우 등록된 건물 태그가 있이 나와요.
클릭하면 해당 바텀시트도 나옵니다.
### 스크린샷 (선택)

https://github.com/user-attachments/assets/cde1211f-c5ac-458b-99bc-b270d1d37d24

지도에서 건물 클릭했을 때 등록된 건물일 경우에 나오는 바텀시트가 나와요.
<img width="417" height="761" alt="image" src="https://github.com/user-attachments/assets/535c4c91-7993-40f6-b782-b89b78abd88f" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
등록된 건물을 젤 위에 해야할지도 고민해봣어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 검색 페이지에서 실시간 API 기반 장소 검색 기능 추가
  * 사용자 현재 위치 감지 및 자동 반영 기능 추가
  * 지도에서 특정 영역을 클릭하여 주변 장소 조회 기능 추가
  * 지도에 단일 마커 표시 기능 추가
  * 지도 상단에 알림 메시지 표시 기능 추가

* **개선 사항**
  * 검색 결과에서 지도 페이지로 이동 시 자동으로 해당 장소 표시

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/insideout-CapstoneDesign/user-mobile/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->