### PR TITLE
feat: 길찾기 경로 검색 페이지 및 로직 구현 (#30)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,22 +5,25 @@ import LoginPage from './pages/Login/LoginPage'
 import SplashPage from './pages/Splash/SplashPage'
 import SignupPage from './pages/Signup/SignupPage'
 import MapPage from './pages/MapPage/MapPage'
+import RoutingSearchPage from './pages/RoutingSearchPage/RoutingSearchPage'
 import SearchPage from './pages/SearchPage/SearchPage'
 import RoutingPage from './pages/RoutingPage/RoutingPage'
+import { ROUTES } from './constants/routes'
 
 function App() {
   return (
     <BrowserRouter>
       <AppLayout>
         <Routes>
-          <Route path="/" element={<SplashPage />} />
-          <Route path="/map" element={<MapPage />} />
-          <Route path="/routing" element={<RoutingPage />} />
-          <Route path="/RoutingPage" element={<RoutingPage />} />
-          <Route path="/search" element={<SearchPage />} />
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/signup" element={<SignupPage />} />
-          <Route path="/component-test" element={<ComponentTestPage />} />
+          <Route path={ROUTES.HOME} element={<SplashPage />} />
+          <Route path={ROUTES.MAP} element={<MapPage />} />
+          <Route path={ROUTES.ROUTING_SEARCH} element={<RoutingSearchPage />} />
+          <Route path={ROUTES.ROUTING} element={<RoutingPage />} />
+          <Route path={ROUTES.ROUTING_LEGACY} element={<RoutingPage />} />
+          <Route path={ROUTES.SEARCH} element={<SearchPage />} />
+          <Route path={ROUTES.LOGIN} element={<LoginPage />} />
+          <Route path={ROUTES.SIGNUP} element={<SignupPage />} />
+          <Route path={ROUTES.COMPONENT_TEST} element={<ComponentTestPage />} />
         </Routes>
       </AppLayout>
     </BrowserRouter>

--- a/src/components/Map/KakaoMapView.jsx
+++ b/src/components/Map/KakaoMapView.jsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import useCurrentLocationOnKakaoMap from '../../hooks/map/useCurrentLocationOnKakaoMap'
 import useKakaoMapInstance from '../../hooks/map/useKakaoMapInstance'
 import usePoiSelectionOnMap from '../../hooks/map/usePoiSelectionOnMap'
@@ -16,6 +16,8 @@ export default function KakaoMapView({
   markerPosition = null,
   markerOffsetY = 0,
   onCurrentLocationSelect,
+  onCenterChange,
+  onLevelChange,
 }) {
   const appKey = import.meta.env.VITE_KAKAO_MAP_APP_KEY
   const mapRef = useRef(null)
@@ -34,6 +36,27 @@ export default function KakaoMapView({
     onMapClick,
   })
   useSingleMarkerOnMap({ map, markerPosition, markerOffsetY })
+
+  useEffect(() => {
+    if (!map || (!onCenterChange && !onLevelChange) || !window.kakao?.maps?.event) {
+      return
+    }
+
+    const handleIdle = () => {
+      const centerPosition = map.getCenter()
+      onCenterChange?.({
+        lat: centerPosition.getLat(),
+        lng: centerPosition.getLng(),
+      })
+      onLevelChange?.(map.getLevel())
+    }
+
+    window.kakao.maps.event.addListener(map, 'idle', handleIdle)
+
+    return () => {
+      window.kakao.maps.event.removeListener(map, 'idle', handleIdle)
+    }
+  }, [map, onCenterChange, onLevelChange])
 
   const { isLocating, geoMessage, moveToCurrentLocation } =
     useCurrentLocationOnKakaoMap(map, onCurrentLocationSelect)

--- a/src/constants/map.js
+++ b/src/constants/map.js
@@ -1,0 +1,2 @@
+export const DEFAULT_MAP_CENTER = { lat: 37.558107, lng: 126.998945 }
+export const DEFAULT_MAP_LEVEL = 3

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -1,0 +1,11 @@
+export const ROUTES = {
+  HOME: '/',
+  MAP: '/map',
+  ROUTING: '/routing',
+  ROUTING_LEGACY: '/RoutingPage',
+  ROUTING_SEARCH: '/RoutingSearchPage',
+  SEARCH: '/search',
+  LOGIN: '/login',
+  SIGNUP: '/signup',
+  COMPONENT_TEST: '/component-test',
+}

--- a/src/constants/search.js
+++ b/src/constants/search.js
@@ -1,0 +1,3 @@
+export const SEARCH_MODES = {
+  ROUTE: 'route',
+}

--- a/src/hooks/map/useKakaoMapInstance.js
+++ b/src/hooks/map/useKakaoMapInstance.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import loadKakaoSdk from '../../services/map/loadKakaoSdk'
 
 export default function useKakaoMapInstance({
@@ -10,6 +10,9 @@ export default function useKakaoMapInstance({
   const [status, setStatus] = useState(appKey ? 'loading' : 'error-key')
   const [errorMessage, setErrorMessage] = useState('')
   const [map, setMap] = useState(null)
+  const kakaoRef = useRef(null)
+  const initialCenterRef = useRef(center)
+  const initialLevelRef = useRef(level)
 
   useEffect(() => {
     if (!appKey) return
@@ -20,10 +23,14 @@ export default function useKakaoMapInstance({
       .then((kakao) => {
         if (!isMounted || !mapRef.current) return
 
-        const mapCenter = new kakao.maps.LatLng(center.lat, center.lng)
+        kakaoRef.current = kakao
+        const mapCenter = new kakao.maps.LatLng(
+          initialCenterRef.current.lat,
+          initialCenterRef.current.lng,
+        )
         const nextMap = new kakao.maps.Map(mapRef.current, {
           center: mapCenter,
-          level,
+          level: initialLevelRef.current,
         })
 
         setMap(nextMap)
@@ -39,7 +46,28 @@ export default function useKakaoMapInstance({
     return () => {
       isMounted = false
     }
-  }, [appKey, center.lat, center.lng, level, mapRef])
+  }, [appKey, mapRef])
+
+  useEffect(() => {
+    if (!map || !kakaoRef.current) return
+
+    const currentCenter = map.getCenter()
+    const currentLat = currentCenter.getLat()
+    const currentLng = currentCenter.getLng()
+
+    if (currentLat === center.lat && currentLng === center.lng) {
+      return
+    }
+
+    map.setCenter(new kakaoRef.current.maps.LatLng(center.lat, center.lng))
+  }, [center.lat, center.lng, map])
+
+  useEffect(() => {
+    if (!map || typeof level !== 'number' || !Number.isFinite(level)) return
+    if (map.getLevel() === level) return
+
+    map.setLevel(level)
+  }, [level, map])
 
   return {
     map,

--- a/src/pages/MapPage/MapPage.jsx
+++ b/src/pages/MapPage/MapPage.jsx
@@ -5,17 +5,18 @@ import BottomNav from '../../components/BottomNav/BottomNav'
 import KakaoMapView from '../../components/Map/KakaoMapView'
 import MapPoiSheet from '../../components/Map/MapPoiSheet'
 import SearchInput from '../../components/SearchInput/SearchInput'
+import { DEFAULT_MAP_CENTER, DEFAULT_MAP_LEVEL } from '../../constants/map'
+import { ROUTES } from '../../constants/routes'
 import { mockMapPois } from '../../mocks/map/poi.mock'
 import { mockSearchPlaces } from '../../mocks/search/searchPage.mock'
 import isRegisteredPlace from '../../utils/map/isRegisteredPlace'
+import { isValidMapCenter } from '../../utils/map/mapViewport'
 import { resolvePoiFromSearch } from '../../utils/map/searchPoiResolver'
 import './MapPage.css'
 
 const NEAREST_RADIUS_METERS = 30
 const NOTICE_TIMEOUT_MS = 2400
 const NO_PLACE_CODE = 'PLACE_INFO_NOT_AVAILABLE'
-const DEFAULT_MAP_CENTER = { lat: 37.558107, lng: 126.998945 }
-
 function mapNearestPlaceToPoi(place) {
   return {
     id:
@@ -41,18 +42,21 @@ export default function MapPage() {
       ? resolvePoiFromSearch(selectedSearchPlace, mockMapPois)
       : null
   const [currentNav, setCurrentNav] = useState('map')
-  const [mapCenter, setMapCenter] = useState(() =>
-    initialSelectedPoi &&
-    typeof initialSelectedPoi.lat === 'number' &&
-    typeof initialSelectedPoi.lng === 'number'
+  const initialMapCenter =
+    isValidMapCenter({
+      lat: initialSelectedPoi?.lat,
+      lng: initialSelectedPoi?.lng,
+    })
       ? { lat: initialSelectedPoi.lat, lng: initialSelectedPoi.lng }
-      : DEFAULT_MAP_CENTER,
-  )
+      : DEFAULT_MAP_CENTER
+  const [mapCenter, setMapCenter] = useState(initialMapCenter)
+  const [mapLevel, setMapLevel] = useState(DEFAULT_MAP_LEVEL)
   const [mapNotice, setMapNotice] = useState('')
   const [selectedMarkerPosition, setSelectedMarkerPosition] = useState(() =>
-    initialSelectedPoi &&
-    typeof initialSelectedPoi.lat === 'number' &&
-    typeof initialSelectedPoi.lng === 'number'
+    isValidMapCenter({
+      lat: initialSelectedPoi?.lat,
+      lng: initialSelectedPoi?.lng,
+    })
       ? { lat: initialSelectedPoi.lat, lng: initialSelectedPoi.lng }
       : null,
   )
@@ -99,11 +103,11 @@ export default function MapPage() {
         maximumAge: 60000,
       },
     )
-  }, [shouldOpenFromSearch])
+  }, [setMapCenter, shouldOpenFromSearch])
 
   useEffect(() => {
     if (!selectedSearchPlace) return
-    navigate('/map', { replace: true, state: null })
+    navigate(ROUTES.MAP, { replace: true, state: null })
   }, [navigate, selectedSearchPlace])
 
   const showMapNotice = (message) => {
@@ -124,7 +128,7 @@ export default function MapPage() {
   }
 
   const openSearchPage = () => {
-    navigate('/search')
+    navigate(ROUTES.SEARCH)
   }
 
   const handleSearchInputKeyDown = (event) => {
@@ -132,6 +136,20 @@ export default function MapPage() {
       event.preventDefault()
       openSearchPage()
     }
+  }
+
+  const handleBottomNavChange = (key) => {
+    if (key === 'navigation') {
+      navigate(ROUTES.ROUTING_SEARCH, {
+        state: {
+          mapCenter,
+          mapLevel,
+        },
+      })
+      return
+    }
+
+    setCurrentNav(key)
   }
 
   const handleCurrentLocationSelect = ({ lat, lng }) => {
@@ -186,11 +204,14 @@ export default function MapPage() {
       <div className="map-page__viewport">
         <KakaoMapView
           center={mapCenter}
+          level={mapLevel}
           pois={[]}
           markerPosition={selectedMarkerPosition}
           markerOffsetY={selectedPoi ? -200 : 0}
           onCurrentLocationSelect={handleCurrentLocationSelect}
           onMapClick={handleMapClick}
+          onCenterChange={setMapCenter}
+          onLevelChange={setMapLevel}
         />
       </div>
 
@@ -205,7 +226,7 @@ export default function MapPage() {
       </div>
       {mapNotice ? <p className="map-page__notice">{mapNotice}</p> : null}
 
-      <BottomNav currentKey={currentNav} onChange={setCurrentNav} />
+      <BottomNav currentKey={currentNav} onChange={handleBottomNavChange} />
 
       <MapPoiSheet
         key={selectedPoi?.id ?? 'map-poi-sheet'}

--- a/src/pages/RoutingSearchPage/RoutingSearchPage.css
+++ b/src/pages/RoutingSearchPage/RoutingSearchPage.css
@@ -1,0 +1,69 @@
+.routing-search-page {
+  position: relative;
+  height: 100dvh;
+}
+
+.routing-search-page__viewport {
+  position: absolute;
+  inset: 0;
+}
+
+.routing-search-page__panel {
+  position: absolute;
+  top: 4.25rem;
+  left: var(--space-16);
+  right: var(--space-16);
+  z-index: 12;
+  display: grid;
+  gap: var(--space-10);
+  padding: var(--space-16);
+  border-radius: var(--radius-8);
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: var(--shadow-searchbar);
+}
+
+.routing-search-page__field {
+  width: 100%;
+  min-height: 2.875rem;
+  display: grid;
+  grid-template-columns: var(--size-16) minmax(0, 1fr);
+  align-items: center;
+  column-gap: var(--space-10);
+  padding: 0 var(--space-14);
+  border: var(--size-1) solid #cfd6df;
+  border-radius: var(--radius-8);
+  background: var(--surface-0);
+  color: var(--gray-600);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.routing-search-page__field:focus-visible {
+  outline: 2px solid var(--blue-500);
+  outline-offset: 2px;
+}
+
+.routing-search-page__dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: var(--radius-pill);
+}
+
+.routing-search-page__dot--origin {
+  background: var(--blue-500);
+}
+
+.routing-search-page__dot--destination {
+  background: var(--red-500);
+}
+
+.routing-search-page__field-text {
+  overflow: hidden;
+  color: var(--gray-500);
+  font-size: var(--text-16);
+  font-weight: var(--fw-medium);
+  line-height: var(--line-24);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/pages/RoutingSearchPage/RoutingSearchPage.jsx
+++ b/src/pages/RoutingSearchPage/RoutingSearchPage.jsx
@@ -30,7 +30,7 @@ export default function RoutingSearchPage() {
   }, [routeOrigin])
 
   const destinationLabel = useMemo(
-    () => getPlaceName(routeDestination, '도착지 입력 (예: 공학관 601호)'),
+    () => getPlaceName(routeDestination, '도착지 입력'),
     [routeDestination],
   )
 

--- a/src/pages/RoutingSearchPage/RoutingSearchPage.jsx
+++ b/src/pages/RoutingSearchPage/RoutingSearchPage.jsx
@@ -1,0 +1,103 @@
+import { useMemo, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import BottomNav from '../../components/BottomNav/BottomNav'
+import KakaoMapView from '../../components/Map/KakaoMapView'
+import { ROUTES } from '../../constants/routes'
+import { SEARCH_MODES } from '../../constants/search'
+import { getMapViewportState } from '../../utils/map/mapViewport'
+import { DEFAULT_ROUTE_ORIGIN } from '../../utils/map/navigationPlaceMapper'
+import './RoutingSearchPage.css'
+
+function getPlaceName(place, fallback) {
+  return place?.title ?? place?.name ?? fallback
+}
+
+export default function RoutingSearchPage() {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const routeOrigin = location.state?.routeOrigin ?? DEFAULT_ROUTE_ORIGIN
+  const routeDestination = location.state?.routeDestination ?? null
+  const initialMapViewport = getMapViewportState(location.state)
+  const [mapCenter, setMapCenter] = useState(initialMapViewport.mapCenter)
+  const [mapLevel, setMapLevel] = useState(initialMapViewport.mapLevel)
+
+  const originLabel = useMemo(() => {
+    if (routeOrigin?.source === 'current-location') {
+      return '출발지 (현재 위치)'
+    }
+
+    return getPlaceName(routeOrigin, '출발지 입력')
+  }, [routeOrigin])
+
+  const destinationLabel = useMemo(
+    () => getPlaceName(routeDestination, '도착지 입력 (예: 공학관 601호)'),
+    [routeDestination],
+  )
+
+  const openRouteSearch = (field) => {
+    navigate(ROUTES.SEARCH, {
+      state: {
+        mode: SEARCH_MODES.ROUTE,
+        routeField: field,
+        returnTo: ROUTES.ROUTING_SEARCH,
+        routeOrigin,
+        routeDestination,
+        mapCenter,
+        mapLevel,
+      },
+    })
+  }
+
+  const handleBottomNavChange = (key) => {
+    if (key === 'map') {
+      navigate(ROUTES.MAP)
+    }
+  }
+
+  return (
+    <main className="routing-search-page">
+      <div className="routing-search-page__viewport">
+        <KakaoMapView
+          center={mapCenter}
+          level={mapLevel}
+          pois={[]}
+          onCenterChange={setMapCenter}
+          onLevelChange={setMapLevel}
+        />
+      </div>
+
+      <section
+        className="routing-search-page__panel"
+        aria-label="경로찾기"
+      >
+        <button
+          type="button"
+          className="routing-search-page__field"
+          onClick={() => openRouteSearch('origin')}
+        >
+          <span
+            className="routing-search-page__dot routing-search-page__dot--origin"
+            aria-hidden="true"
+          />
+          <span className="routing-search-page__field-text">{originLabel}</span>
+        </button>
+
+        <button
+          type="button"
+          className="routing-search-page__field"
+          onClick={() => openRouteSearch('destination')}
+        >
+          <span
+            className="routing-search-page__dot routing-search-page__dot--destination"
+            aria-hidden="true"
+          />
+          <span className="routing-search-page__field-text">
+            {destinationLabel}
+          </span>
+        </button>
+      </section>
+
+      <BottomNav currentKey="navigation" onChange={handleBottomNavChange} />
+    </main>
+  )
+}

--- a/src/pages/RoutingSearchPage/RoutingSearchPage.jsx
+++ b/src/pages/RoutingSearchPage/RoutingSearchPage.jsx
@@ -23,7 +23,7 @@ export default function RoutingSearchPage() {
 
   const originLabel = useMemo(() => {
     if (routeOrigin?.source === 'current-location') {
-      return '출발지 (현재 위치)'
+      return '출발지'
     }
 
     return getPlaceName(routeOrigin, '출발지 입력')

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -1,9 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { searchPlaces } from '../../apis/placeApi'
 import CommonHeader from '../../components/CommonHeader/CommonHeader'
 import SearchAutocompleteList from '../../components/Search/SearchAutocompleteList'
 import SearchResultList from '../../components/Search/SearchResultList'
+import { ROUTES } from '../../constants/routes'
+import { SEARCH_MODES } from '../../constants/search'
 import { mockAutocompleteKeywords } from '../../mocks/search/searchPage.mock'
 import './SearchPage.css'
 
@@ -13,7 +15,15 @@ const GEOLOCATION_UNAVAILABLE_MESSAGE = '현재 위치 정보를 사용할 수 �
 const GEOLOCATION_REQUIRED_MESSAGE = '현재 위치를 확인한 뒤 다시 검색해 주세요.'
 
 export default function SearchPage() {
+  const location = useLocation()
   const navigate = useNavigate()
+  const searchMode = location.state?.mode
+  const routeField = location.state?.routeField
+  const returnTo = location.state?.returnTo ?? ROUTES.ROUTING_SEARCH
+  const routeOrigin = location.state?.routeOrigin ?? null
+  const routeDestination = location.state?.routeDestination ?? null
+  const mapCenter = location.state?.mapCenter ?? null
+  const mapLevel = location.state?.mapLevel ?? null
   const supportsGeolocation =
     typeof navigator !== 'undefined' && 'geolocation' in navigator
   const [keyword, setKeyword] = useState('')
@@ -157,7 +167,25 @@ export default function SearchPage() {
   }
 
   const handleSelectResult = (selectedPlace) => {
-    navigate('/map', {
+    if (searchMode === SEARCH_MODES.ROUTE) {
+      const nextOrigin = routeField === 'origin' ? selectedPlace : routeOrigin
+      const nextDestination =
+        routeField === 'destination' ? selectedPlace : routeDestination
+
+      navigate(returnTo, {
+        state: {
+          routeOrigin: nextOrigin,
+          routeDestination: nextDestination,
+          mapCenter,
+          mapLevel,
+          selectedRouteField: routeField,
+          isRouteReady: Boolean(nextOrigin && nextDestination),
+        },
+      })
+      return
+    }
+
+    navigate(ROUTES.MAP, {
       state: {
         selectedSearchPlace: selectedPlace,
         openSheetFrom: 'search-result',

--- a/src/utils/map/mapViewport.js
+++ b/src/utils/map/mapViewport.js
@@ -14,11 +14,16 @@ export function isValidMapLevel(level) {
   return typeof level === 'number' && Number.isFinite(level)
 }
 
-export function getMapViewportState(state = {}) {
+export function getMapViewportState(state) {
+  const safeState =
+    state && typeof state === 'object' ? state : {}
+
   return {
-    mapCenter: isValidMapCenter(state.mapCenter)
-      ? state.mapCenter
+    mapCenter: isValidMapCenter(safeState.mapCenter)
+      ? safeState.mapCenter
       : DEFAULT_MAP_CENTER,
-    mapLevel: isValidMapLevel(state.mapLevel) ? state.mapLevel : DEFAULT_MAP_LEVEL,
+    mapLevel: isValidMapLevel(safeState.mapLevel)
+      ? safeState.mapLevel
+      : DEFAULT_MAP_LEVEL,
   }
 }

--- a/src/utils/map/mapViewport.js
+++ b/src/utils/map/mapViewport.js
@@ -1,0 +1,24 @@
+import { DEFAULT_MAP_CENTER, DEFAULT_MAP_LEVEL } from '../../constants/map'
+
+export function isValidMapCenter(center) {
+  return (
+    center &&
+    typeof center.lat === 'number' &&
+    Number.isFinite(center.lat) &&
+    typeof center.lng === 'number' &&
+    Number.isFinite(center.lng)
+  )
+}
+
+export function isValidMapLevel(level) {
+  return typeof level === 'number' && Number.isFinite(level)
+}
+
+export function getMapViewportState(state = {}) {
+  return {
+    mapCenter: isValidMapCenter(state.mapCenter)
+      ? state.mapCenter
+      : DEFAULT_MAP_CENTER,
+    mapLevel: isValidMapLevel(state.mapLevel) ? state.mapLevel : DEFAULT_MAP_LEVEL,
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closed #30 

## 📝작업 내용

> 경로검색페이지를 구현했어요
MapPage - RoutingSearchPage - SearchPage로 이어지게 했어요. 흐름은 추후에 RoutingOptionPage로 이을 예정이에요.
MapPage에서 RoutingSearchPage로 갈 때 지도의 중심점 좌표와 확대 레벨을 가져가서 RoutingSearchPage로 넘어갔을 때 지도가 유지되도록 했어요

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

https://github.com/user-attachments/assets/fc89efee-4da3-44a1-911d-c282b47e458d


> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 경로 검색 전용 화면 추가로 지도에서 출발지/도착지를 쉽게 설정 가능
  * 지도 중심 및 줌 레벨 추적으로 사용자가 변경한 지도 상태 유지

* **개선사항**
  * 경로 찾기 모드에서 검색 기능 강화
  * 지도 뷰포트 상태 관리 최적화로 더 안정적인 네비게이션

<!-- end of auto-generated comment: release notes by coderabbit.ai -->