### PR TITLE
[feat] ES 기반 검색/자동완성 연동 및 지도 이동·바텀시트 흐름 개선 (#29)

### DIFF
--- a/src/apis/placeApi.js
+++ b/src/apis/placeApi.js
@@ -1,8 +1,9 @@
-import { ERROR_MESSAGE } from '../constants/errorMessages'
+import { ERROR_MESSAGE, PLACE_ERROR_MESSAGE } from '../constants/errorMessages'
 import getErrorMessage from './utils/getErrorMessage'
 
 const NEAREST_PLACE_PATH = '/api/v1/places/nearest'
 const SEARCH_PLACES_PATH = '/api/v1/places/search'
+const SUGGEST_PLACES_PATH = '/api/v1/places/suggest'
 const REQUEST_TIMEOUT_MS = 10000
 const NO_PLACE_CODES = new Set(['PLACE_INFO_NOT_AVAILABLE', 'PLACE200_1'])
 
@@ -18,6 +19,86 @@ function getApiBaseUrl() {
 
 function isFiniteNumber(value) {
   return typeof value === 'number' && Number.isFinite(value)
+}
+
+function hasLocation(lat, lng) {
+  return isFiniteNumber(lat) && isFiniteNumber(lng)
+}
+
+function validateLocationPair(lat, lng) {
+  const hasLat = isFiniteNumber(lat)
+  const hasLng = isFiniteNumber(lng)
+
+  if ((hasLat && !hasLng) || (!hasLat && hasLng)) {
+    const error = new Error(PLACE_ERROR_MESSAGE.INVALID_COORDINATE)
+    error.code = 'PLACE400_1'
+    throw error
+  }
+}
+
+function validateSize(size) {
+  if (size === undefined) return
+
+  if (!Number.isInteger(size) || size <= 0) {
+    const error = new Error('size 값이 올바르지 않습니다.')
+    error.code = 'PLACE400_3'
+    throw error
+  }
+}
+
+function buildSearchQuery({ keyword, lat, lng, radius, size }) {
+  if (!keyword?.trim()) return null
+  validateLocationPair(lat, lng)
+  validateSize(size)
+
+  if (radius !== undefined && !hasLocation(lat, lng)) {
+    const error = new Error(PLACE_ERROR_MESSAGE.INVALID_COORDINATE)
+    error.code = 'PLACE400_1'
+    throw error
+  }
+
+  if (radius !== undefined && (!isFiniteNumber(radius) || radius <= 0)) {
+    const error = new Error(PLACE_ERROR_MESSAGE.INVALID_RADIUS)
+    error.code = 'PLACE400_2'
+    throw error
+  }
+
+  const queryParams = {
+    q: keyword.trim(),
+  }
+
+  if (hasLocation(lat, lng)) {
+    queryParams.lat = String(lat)
+    queryParams.lng = String(lng)
+  }
+
+  if (radius !== undefined) {
+    queryParams.radius = String(radius)
+  }
+
+  if (size !== undefined) {
+    queryParams.size = String(size)
+  }
+
+  return new URLSearchParams(queryParams).toString()
+}
+
+function getPlaceCodeMap(fallbackType = 'search') {
+  return {
+    PLACE400_1: PLACE_ERROR_MESSAGE.INVALID_COORDINATE,
+    PLACE400_2: PLACE_ERROR_MESSAGE.INVALID_RADIUS,
+    PLACE400_3: PLACE_ERROR_MESSAGE.INVALID_QUERY,
+    PLACE503_1: PLACE_ERROR_MESSAGE.KAKAO_UNAVAILABLE,
+    PLACE503_2: PLACE_ERROR_MESSAGE.SEARCH_UNAVAILABLE,
+    INVALID_COORDINATE: PLACE_ERROR_MESSAGE.INVALID_COORDINATE,
+    INVALID_RADIUS: PLACE_ERROR_MESSAGE.INVALID_RADIUS,
+    SEARCH_INVALID_QUERY: PLACE_ERROR_MESSAGE.INVALID_QUERY,
+    KAKAO_LOCAL_API_UNAVAILABLE: PLACE_ERROR_MESSAGE.KAKAO_UNAVAILABLE,
+    SEARCH_SERVICE_UNAVAILABLE: PLACE_ERROR_MESSAGE.SEARCH_UNAVAILABLE,
+    ...(fallbackType === 'suggest'
+      ? { COMMON400_1: PLACE_ERROR_MESSAGE.INVALID_QUERY }
+      : {}),
+  }
 }
 
 async function getJson(path, options = {}) {
@@ -101,10 +182,7 @@ export async function getNearestPlace({ lat, lng, radius = 30 }) {
 
   const data = await getJson(`${NEAREST_PLACE_PATH}?${query}`, {
     fallbackMessage: '장소 정보를 불러오지 못했습니다.',
-    codeMap: {
-      PLACE400_1: '좌표 정보가 올바르지 않습니다.',
-      PLACE400_2: '반경 정보가 올바르지 않습니다.',
-    },
+    codeMap: getPlaceCodeMap(),
   })
 
   if (NO_PLACE_CODES.has(data?.code) || data?.result == null) {
@@ -114,34 +192,30 @@ export async function getNearestPlace({ lat, lng, radius = 30 }) {
   return { place: data.result, code: data?.code }
 }
 
-export async function searchPlaces({ keyword, lat, lng, radius }) {
-  if (!keyword?.trim()) return []
+export async function searchPlaces({ keyword, lat, lng, radius, size }) {
+  const query = buildSearchQuery({ keyword, lat, lng, radius, size })
+  if (!query) return []
 
-  if (!isFiniteNumber(lat) || !isFiniteNumber(lng)) {
-    const error = new Error('현재 위치 정보를 확인할 수 없습니다.')
-    error.code = 'PLACE400_1'
-    throw error
-  }
-
-  if (radius !== undefined && (!isFiniteNumber(radius) || radius <= 0)) {
-    const error = new Error('반경 정보가 올바르지 않습니다.')
-    error.code = 'PLACE400_2'
-    throw error
-  }
-
-  const queryParams = {
-    q: keyword.trim(),
-    lat: String(lat),
-    lng: String(lng),
-  }
-
-  if (radius !== undefined) {
-    queryParams.radius = String(radius)
-  }
-
-  const query = new URLSearchParams(queryParams).toString()
   const data = await getJson(`${SEARCH_PLACES_PATH}?${query}`, {
-    fallbackMessage: '검색 결과를 불러오지 못했습니다.',
+    fallbackMessage: PLACE_ERROR_MESSAGE.SEARCH_FAILED,
+    codeMap: getPlaceCodeMap('search'),
+  })
+
+  const rawResult = data?.result
+
+  if (Array.isArray(rawResult)) return rawResult
+  if (Array.isArray(rawResult?.content)) return rawResult.content
+
+  return []
+}
+
+export async function suggestPlaces({ keyword, lat, lng, size }) {
+  const query = buildSearchQuery({ keyword, lat, lng, size })
+  if (!query) return []
+
+  const data = await getJson(`${SUGGEST_PLACES_PATH}?${query}`, {
+    fallbackMessage: PLACE_ERROR_MESSAGE.SUGGEST_FAILED,
+    codeMap: getPlaceCodeMap('suggest'),
   })
 
   const rawResult = data?.result

--- a/src/components/Search/SearchAutocompleteList.jsx
+++ b/src/components/Search/SearchAutocompleteList.jsx
@@ -12,12 +12,16 @@ export default function SearchAutocompleteList({ items = [], onSelect }) {
     <AutocompleteSection>
       <SectionTitle>자동완성</SectionTitle>
       <KeywordList>
-        {items.map((item) => (
-          <KeywordItem key={item} type="button" onClick={() => onSelect?.(item)}>
+        {items.map((item, index) => (
+          <KeywordItem
+            key={item.id ?? `${item.title}-${index}`}
+            type="button"
+            onClick={() => onSelect?.(item)}
+          >
             <KeywordIcon>
               <IoSearchOutline size={14} />
             </KeywordIcon>
-            <span>{item}</span>
+            <span>{item.title}</span>
           </KeywordItem>
         ))}
       </KeywordList>

--- a/src/components/Search/SearchResultItem.jsx
+++ b/src/components/Search/SearchResultItem.jsx
@@ -5,11 +5,26 @@ import {
   Title,
   Badge,
   Address,
+  Distance,
   ArrowIcon
 } from './SearchResultItem.styles'
 import RightArrow from '../../assets/icons/right-arrow.svg'
 
-export default function SearchResultItem({ title, address, isRegistered, onClick }) {
+function formatDistance(distanceMeters) {
+  if (typeof distanceMeters !== 'number' || Number.isNaN(distanceMeters)) return ''
+  if (distanceMeters < 1000) return `${Math.round(distanceMeters)}m`
+  return `${(distanceMeters / 1000).toFixed(1)}km`
+}
+
+export default function SearchResultItem({
+  title,
+  address,
+  isRegistered,
+  distanceMeters,
+  onClick,
+}) {
+  const distanceText = formatDistance(distanceMeters)
+
   return (
     <Container type="button" onClick={onClick}>
       <InfoWrapper>
@@ -18,6 +33,7 @@ export default function SearchResultItem({ title, address, isRegistered, onClick
           {isRegistered && <Badge>등록됨</Badge>}
         </TitleRow>
         <Address>{address}</Address>
+        {distanceText ? <Distance>{distanceText}</Distance> : null}
       </InfoWrapper>
       <ArrowIcon src={RightArrow} alt="" aria-hidden="true" />
     </Container>

--- a/src/components/Search/SearchResultItem.styles.js
+++ b/src/components/Search/SearchResultItem.styles.js
@@ -59,6 +59,13 @@ export const Address = styled.span`
   line-height: var(--line-20);
 `
 
+export const Distance = styled.span`
+  font-family: var(--font-sans);
+  font-size: var(--text-12);
+  color: var(--gray-500);
+  line-height: var(--line-16);
+`
+
 export const ArrowIcon = styled.img`
   width: var(--size-20);
   height: var(--size-20);

--- a/src/components/Search/SearchResultList.jsx
+++ b/src/components/Search/SearchResultList.jsx
@@ -10,6 +10,7 @@ export default function SearchResultList({ items = [], onSelect }) {
           title={item.title}
           address={item.address}
           isRegistered={item.isRegistered}
+          distanceMeters={item.distanceMeters}
           onClick={() => onSelect?.(item)}
         />
       ))}

--- a/src/constants/errorMessages.js
+++ b/src/constants/errorMessages.js
@@ -8,3 +8,13 @@ export const AUTH_ERROR_MESSAGE = {
   LOGIN_FAILED: '이메일 또는 비밀번호가 올바르지 않습니다.',
   SIGNUP_FAILED: '회원가입에 실패했습니다. 입력 정보를 확인해 주세요.',
 }
+
+export const PLACE_ERROR_MESSAGE = {
+  INVALID_COORDINATE: '좌표 정보가 올바르지 않습니다.',
+  INVALID_RADIUS: '반경 정보가 올바르지 않습니다.',
+  INVALID_QUERY: '검색어를 확인해 주세요.',
+  KAKAO_UNAVAILABLE: '외부 지도 검색 서비스에 일시적인 문제가 발생했습니다.',
+  SEARCH_UNAVAILABLE: '검색 서비스에 일시적인 문제가 발생했습니다.',
+  SEARCH_FAILED: '검색 결과를 불러오지 못했습니다.',
+  SUGGEST_FAILED: '자동완성 결과를 불러오지 못했습니다.',
+}

--- a/src/pages/MapPage/MapPage.jsx
+++ b/src/pages/MapPage/MapPage.jsx
@@ -40,6 +40,7 @@ export default function MapPage() {
     shouldOpenFromSearch && selectedSearchPlace
       ? resolvePoiFromSearch(selectedSearchPlace, mockMapPois)
       : null
+  const shouldSkipAutoLocateRef = useRef(Boolean(initialSelectedPoi))
   const [currentNav, setCurrentNav] = useState('map')
   const [mapCenter, setMapCenter] = useState(() =>
     initialSelectedPoi &&
@@ -80,7 +81,7 @@ export default function MapPage() {
   }, [])
 
   useEffect(() => {
-    if (shouldOpenFromSearch) return
+    if (shouldSkipAutoLocateRef.current) return
     if (!navigator.geolocation) return
 
     navigator.geolocation.getCurrentPosition(
@@ -99,7 +100,7 @@ export default function MapPage() {
         maximumAge: 60000,
       },
     )
-  }, [shouldOpenFromSearch])
+  }, [])
 
   useEffect(() => {
     if (!selectedSearchPlace) return

--- a/src/pages/MapPage/MapPage.jsx
+++ b/src/pages/MapPage/MapPage.jsx
@@ -1,14 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { getNearestPlace } from '../../apis/placeApi'
 import BottomNav from '../../components/BottomNav/BottomNav'
 import KakaoMapView from '../../components/Map/KakaoMapView'
 import MapPoiSheet from '../../components/Map/MapPoiSheet'
 import SearchInput from '../../components/SearchInput/SearchInput'
-import { mockMapPois } from '../../mocks/map/poi.mock'
-import { mockSearchPlaces } from '../../mocks/search/searchPage.mock'
-import isRegisteredPlace from '../../utils/map/isRegisteredPlace'
-import { resolvePoiFromSearch } from '../../utils/map/searchPoiResolver'
 import './MapPage.css'
 
 const NEAREST_RADIUS_METERS = 30
@@ -18,14 +14,28 @@ const DEFAULT_MAP_CENTER = { lat: 37.558107, lng: 126.998945 }
 
 function mapNearestPlaceToPoi(place) {
   return {
-    id:
-      place.externalApiId ??
-      place.id ??
-      `${place.name ?? place.placeName ?? 'place'}-${place.lat}-${place.lng}`,
-    name: place.name ?? place.placeName ?? place.title ?? '장소명',
+    id: place.externalApiId ?? `${place.name ?? 'place'}-${place.lat}-${place.lng}`,
+    name: place.name ?? '장소명',
     address: place.roadAddress || place.address || '주소 정보 없음',
     lat: place.lat,
     lng: place.lng,
+    isRegistered: Boolean(place.isRegistered),
+    externalApiId: place.externalApiId,
+  }
+}
+
+function mapSearchPlaceToPoi(place) {
+  if (!place) return null
+
+  const hasLat = typeof place.lat === 'number' && Number.isFinite(place.lat)
+  const hasLng = typeof place.lng === 'number' && Number.isFinite(place.lng)
+
+  return {
+    id: place.externalApiId ?? `search-${place.name ?? 'place'}`,
+    name: place.name ?? '장소명',
+    address: place.address ?? place.roadAddress ?? '주소 정보 없음',
+    lat: hasLat ? place.lat : null,
+    lng: hasLng ? place.lng : null,
     isRegistered: Boolean(place.isRegistered),
     externalApiId: place.externalApiId,
   }
@@ -38,9 +48,9 @@ export default function MapPage() {
   const shouldOpenFromSearch = location.state?.openSheetFrom === 'search-result'
   const initialSelectedPoi =
     shouldOpenFromSearch && selectedSearchPlace
-      ? resolvePoiFromSearch(selectedSearchPlace, mockMapPois)
+      ? mapSearchPlaceToPoi(selectedSearchPlace)
       : null
-  const shouldSkipAutoLocateRef = useRef(Boolean(initialSelectedPoi))
+  const shouldSkipAutoLocate = Boolean(initialSelectedPoi)
   const [currentNav, setCurrentNav] = useState('map')
   const [mapCenter, setMapCenter] = useState(() =>
     initialSelectedPoi &&
@@ -60,28 +70,16 @@ export default function MapPage() {
   const [selectedPoi, setSelectedPoi] = useState(initialSelectedPoi)
   const requestSeqRef = useRef(0)
   const noticeTimerRef = useRef(null)
-  const registeredPlaces = useMemo(
-    () => mockSearchPlaces.filter((place) => place.isRegistered),
-    [],
-  )
-  const isSelectedPoiRegistered = useMemo(
-    () =>
-      typeof selectedPoi?.isRegistered === 'boolean'
-        ? selectedPoi.isRegistered
-        : isRegisteredPlace(selectedPoi, registeredPlaces),
-    [registeredPlaces, selectedPoi],
-  )
-
   useEffect(() => {
     return () => {
       if (noticeTimerRef.current) {
         window.clearTimeout(noticeTimerRef.current)
       }
     }
-  }, [])
+  }, [shouldSkipAutoLocate])
 
   useEffect(() => {
-    if (shouldSkipAutoLocateRef.current) return
+    if (shouldSkipAutoLocate) return
     if (!navigator.geolocation) return
 
     navigator.geolocation.getCurrentPosition(
@@ -91,16 +89,14 @@ export default function MapPage() {
           lng: coords.longitude,
         })
       },
-      () => {
-        // 권한 거부/실패 시 기본 중심 좌표(동국대)를 유지합니다.
-      },
+      () => {},
       {
         enableHighAccuracy: true,
         timeout: 10000,
         maximumAge: 60000,
       },
     )
-  }, [])
+  }, [shouldSkipAutoLocate])
 
   useEffect(() => {
     if (!selectedSearchPlace) return
@@ -212,7 +208,7 @@ export default function MapPage() {
         key={selectedPoi?.id ?? 'map-poi-sheet'}
         isOpen={!!selectedPoi}
         place={selectedPoi}
-        isRegistered={isSelectedPoiRegistered}
+        isRegistered={Boolean(selectedPoi?.isRegistered)}
         onClose={closePoiSheet}
       />
     </main>

--- a/src/pages/MapPage/MapPage.jsx
+++ b/src/pages/MapPage/MapPage.jsx
@@ -31,8 +31,8 @@ function mapSearchPlaceToPoi(place) {
   const hasLng = typeof place.lng === 'number' && Number.isFinite(place.lng)
 
   return {
-    id: place.externalApiId ?? `search-${place.name ?? 'place'}`,
-    name: place.name ?? '장소명',
+    id: place.externalApiId ?? `search-${place.title ?? place.name ?? 'place'}`,
+    name: place.title ?? place.name ?? '장소명',
     address: place.address ?? place.roadAddress ?? '주소 정보 없음',
     lat: hasLat ? place.lat : null,
     lng: hasLng ? place.lng : null,
@@ -50,7 +50,7 @@ export default function MapPage() {
     shouldOpenFromSearch && selectedSearchPlace
       ? mapSearchPlaceToPoi(selectedSearchPlace)
       : null
-  const shouldSkipAutoLocate = Boolean(initialSelectedPoi)
+  const shouldSkipAutoLocateRef = useRef(Boolean(initialSelectedPoi))
   const [currentNav, setCurrentNav] = useState('map')
   const [mapCenter, setMapCenter] = useState(() =>
     initialSelectedPoi &&
@@ -76,10 +76,10 @@ export default function MapPage() {
         window.clearTimeout(noticeTimerRef.current)
       }
     }
-  }, [shouldSkipAutoLocate])
+  }, [])
 
   useEffect(() => {
-    if (shouldSkipAutoLocate) return
+    if (shouldSkipAutoLocateRef.current) return
     if (!navigator.geolocation) return
 
     navigator.geolocation.getCurrentPosition(
@@ -96,7 +96,7 @@ export default function MapPage() {
         maximumAge: 60000,
       },
     )
-  }, [shouldSkipAutoLocate])
+  }, [])
 
   useEffect(() => {
     if (!selectedSearchPlace) return

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -1,16 +1,24 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { searchPlaces } from '../../apis/placeApi'
+import { searchPlaces, suggestPlaces } from '../../apis/placeApi'
 import CommonHeader from '../../components/CommonHeader/CommonHeader'
 import SearchAutocompleteList from '../../components/Search/SearchAutocompleteList'
 import SearchResultList from '../../components/Search/SearchResultList'
-import { mockAutocompleteKeywords } from '../../mocks/search/searchPage.mock'
 import './SearchPage.css'
 
 const SEARCH_DELAY_MS = 250
+const SUGGEST_DELAY_MS = 180
+const SEARCH_SIZE = 15
+const SUGGEST_SIZE = 10
 const normalizeText = (value = '') => value.trim().toLowerCase()
+const HANGUL_JAMO_ONLY_REGEX = /^[ㄱ-ㅎㅏ-ㅣ]+$/
 const GEOLOCATION_UNAVAILABLE_MESSAGE = '현재 위치 정보를 사용할 수 없습니다.'
 const GEOLOCATION_REQUIRED_MESSAGE = '현재 위치를 확인한 뒤 다시 검색해 주세요.'
+const SEARCH_FAILED_MESSAGE = '검색 결과를 불러오지 못했습니다.'
+
+function isInvalidIntermediateKeyword(keyword) {
+  return HANGUL_JAMO_ONLY_REGEX.test(keyword)
+}
 
 export default function SearchPage() {
   const navigate = useNavigate()
@@ -24,9 +32,12 @@ export default function SearchPage() {
     supportsGeolocation ? '' : GEOLOCATION_UNAVAILABLE_MESSAGE,
   )
   const [searchCenter, setSearchCenter] = useState(null)
+  const [autocompleteItems, setAutocompleteItems] = useState([])
   const [resultItems, setResultItems] = useState([])
   const searchTimerRef = useRef(null)
+  const suggestTimerRef = useRef(null)
   const requestSeqRef = useRef(0)
+  const suggestSeqRef = useRef(0)
 
   const invalidatePendingSearch = () => {
     requestSeqRef.current += 1
@@ -36,12 +47,25 @@ export default function SearchPage() {
     }
   }
 
+  const invalidatePendingSuggest = () => {
+    suggestSeqRef.current += 1
+    if (suggestTimerRef.current) {
+      window.clearTimeout(suggestTimerRef.current)
+      suggestTimerRef.current = null
+    }
+  }
+
   useEffect(() => {
     return () => {
       requestSeqRef.current += 1
       if (searchTimerRef.current) {
         window.clearTimeout(searchTimerRef.current)
         searchTimerRef.current = null
+      }
+      suggestSeqRef.current += 1
+      if (suggestTimerRef.current) {
+        window.clearTimeout(suggestTimerRef.current)
+        suggestTimerRef.current = null
       }
     }
   }, [])
@@ -67,19 +91,56 @@ export default function SearchPage() {
     )
   }, [supportsGeolocation])
 
-  const autocompleteItems = useMemo(() => {
-    const normalized = normalizeText(keyword)
-    if (!normalized) return mockAutocompleteKeywords
+  const suggestByKeyword = (rawKeyword) => {
+    const normalized = normalizeText(rawKeyword)
 
-    return mockAutocompleteKeywords.filter((item) =>
-      normalizeText(item).includes(normalized),
-    )
-  }, [keyword])
+    if (!normalized || isInvalidIntermediateKeyword(normalized)) {
+      invalidatePendingSuggest()
+      setAutocompleteItems([])
+      return
+    }
+
+    if (suggestTimerRef.current) {
+      window.clearTimeout(suggestTimerRef.current)
+      suggestTimerRef.current = null
+    }
+
+    const requestId = ++suggestSeqRef.current
+
+    suggestTimerRef.current = window.setTimeout(async () => {
+      try {
+        const suggestions = await suggestPlaces({
+          keyword: normalized,
+          lat: searchCenter?.lat,
+          lng: searchCenter?.lng,
+          size: SUGGEST_SIZE,
+        })
+
+        if (requestId !== suggestSeqRef.current) return
+
+        const mappedSuggestions = suggestions.map((item, idx) => ({
+          id: item.externalApiId ?? `${item.name}-${idx}`,
+          title: item.name,
+          address: item.roadAddress || item.address || '주소 정보 없음',
+          isRegistered: Boolean(item.isRegistered),
+          lat: item.lat,
+          lng: item.lng,
+          externalApiId: item.externalApiId,
+          distanceMeters: item.distanceMeters ?? null,
+        }))
+
+        setAutocompleteItems(mappedSuggestions)
+      } catch {
+        if (requestId !== suggestSeqRef.current) return
+        setAutocompleteItems([])
+      }
+    }, SUGGEST_DELAY_MS)
+  }
 
   const runSearch = (rawKeyword) => {
     const normalized = normalizeText(rawKeyword)
 
-    if (!normalized) {
+    if (!normalized || isInvalidIntermediateKeyword(normalized)) {
       invalidatePendingSearch()
       setIsResultMode(false)
       setIsLoading(false)
@@ -115,8 +176,9 @@ export default function SearchPage() {
       try {
         const places = await searchPlaces({
           keyword: normalized,
-          lat: searchCenter.lat,
-          lng: searchCenter.lng,
+          lat: searchCenter?.lat,
+          lng: searchCenter?.lng,
+          size: SEARCH_SIZE,
         })
         if (requestId !== requestSeqRef.current) return
 
@@ -128,13 +190,14 @@ export default function SearchPage() {
           lat: place.lat,
           lng: place.lng,
           externalApiId: place.externalApiId,
+          distanceMeters: place.distanceMeters ?? null,
         }))
 
         setResultItems(mappedPlaces)
       } catch {
         if (requestId !== requestSeqRef.current) return
         setHasSearchError(true)
-        setSearchStateMessage('검색 결과를 불러오지 못했습니다.')
+        setSearchStateMessage(SEARCH_FAILED_MESSAGE)
         setResultItems([])
       } finally {
         if (requestId === requestSeqRef.current) {
@@ -149,11 +212,15 @@ export default function SearchPage() {
     setKeyword(nextKeyword)
     setIsResultMode(false)
     setIsLoading(false)
+    setHasSearchError(false)
+    setSearchStateMessage('')
+    setResultItems([])
+    suggestByKeyword(nextKeyword)
   }
 
-  const handleSelectAutocomplete = (selectedKeyword) => {
-    setKeyword(selectedKeyword)
-    runSearch(selectedKeyword)
+  const handleSelectAutocomplete = (selectedItem) => {
+    setKeyword(selectedItem.title)
+    runSearch(selectedItem.title)
   }
 
   const handleSelectResult = (selectedPlace) => {
@@ -199,7 +266,7 @@ export default function SearchPage() {
         {isResultMode && !isLoading && resultItems.length === 0 ? (
           <p className="search-page__state">
             {hasSearchError
-              ? searchStateMessage || '검색 결과를 불러오지 못했습니다.'
+              ? searchStateMessage || SEARCH_FAILED_MESSAGE
               : '검색 결과가 없습니다.'}
           </p>
         ) : null}

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -194,10 +194,10 @@ export default function SearchPage() {
         }))
 
         setResultItems(mappedPlaces)
-      } catch {
+      } catch (error) {
         if (requestId !== requestSeqRef.current) return
         setHasSearchError(true)
-        setSearchStateMessage(SEARCH_FAILED_MESSAGE)
+        setSearchStateMessage(error?.message || SEARCH_FAILED_MESSAGE)
         setResultItems([])
       } finally {
         if (requestId === requestSeqRef.current) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closed #29 

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
검색엔진에서 자동완성, 오타보정, 엘라스틱 서치 완료 했습니다 ~ 추가로 검색리스트에서 장소 클릭했을 때 해당 위치로 이동하도록 수정했습니다

- Elasticsearch 기반 검색 스펙에 맞춰 프론트 검색 흐름을 정리했어요.
- /search와 /suggest 응답 스펙(name, address, roadAddress, lat, lng, isRegistered, externalApiId, distanceMeters)을 반영했어요.
- 검색 결과 선택 시 지도 중심 이동 + 바텀시트 오픈 흐름을 수정했어요.
- 지도 클릭 nearest 연동 및 단일 마커 동작(재사용/위치 갱신)과 예외 처리를 개선했습니다.
- mock/임시 분기 일부를 제거하고 MapPage 책임 정리했어요.


### 스크린샷 (선택)
https://github.com/user-attachments/assets/b53e20d9-dd78-43a1-97c9-048d1aebab5d

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
RoutingPage에서 api 연동 하시면 mock 데이터 삭제 해주세요~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 실시간 자동완성 제안 추가 (비동기 제안 호출 및 선택 연동)
  * 검색 제안(suggest) 기능 추가

* **개선 사항**
  * 검색 결과에 거리 정보 표시 (m/km)
  * 검색·제안 입력 검증 및 쿼리 생성 강화
  * 장소 관련 오류 메시지의 사용자 안내 개선
  * 지도 페이지의 검색 선택 초기화 및 자동 중심 이동 동작 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->