### PR TITLE
[feat] Mypage ui 구현 (#34)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,12 @@ import MapPage from './pages/MapPage/MapPage'
 import RoutingSearchPage from './pages/RoutingSearchPage/RoutingSearchPage'
 import SearchPage from './pages/SearchPage/SearchPage'
 import RoutingPage from './pages/RoutingPage/RoutingPage'
+import MyPage from './pages/MyPage/MyPage/MyPage'
+import FavoritesPage from './pages/MyPage/FavoritesPage/FavoritesPage'
+import ReviewsPage from './pages/MyPage/ReviewsPage/ReviewsPage'
+import SettingsPage from './pages/MyPage/SettingsPage/SettingsPage'
+import ProfilePage from './pages/MyPage/ProfilePage/ProfilePage'
+import PasswordPage from './pages/MyPage/PasswordPage/PasswordPage'
 import { ROUTES } from './constants/routes'
 
 function App() {
@@ -21,6 +27,12 @@ function App() {
           <Route path={ROUTES.ROUTING} element={<RoutingPage />} />
           <Route path={ROUTES.ROUTING_LEGACY} element={<RoutingPage />} />
           <Route path={ROUTES.SEARCH} element={<SearchPage />} />
+          <Route path="/my" element={<MyPage />} />
+          <Route path="/my/favorites" element={<FavoritesPage />} />
+          <Route path="/my/reviews" element={<ReviewsPage />} />
+          <Route path="/my/settings" element={<SettingsPage />} />
+          <Route path="/my/profile" element={<ProfilePage />} />
+          <Route path="/my/password" element={<PasswordPage />} />
           <Route path={ROUTES.LOGIN} element={<LoginPage />} />
           <Route path={ROUTES.SIGNUP} element={<SignupPage />} />
           <Route path={ROUTES.COMPONENT_TEST} element={<ComponentTestPage />} />

--- a/src/apis/profileApi.js
+++ b/src/apis/profileApi.js
@@ -1,0 +1,156 @@
+import { AUTH_STORAGE_KEY } from '../constants/auth'
+import { ERROR_MESSAGE, PROFILE_ERROR_MESSAGE } from '../constants/errorMessages'
+import getErrorMessage from './utils/getErrorMessage'
+
+const REQUEST_TIMEOUT_MS = 10000
+const DEFAULT_PROFILE_PATH = '/api/v1/users/me'
+
+function getApiBaseUrl() {
+  const apiBaseUrl = import.meta.env.VITE_API_BASE_URL
+
+  if (!apiBaseUrl) {
+    throw new Error('VITE_API_BASE_URL 환경변수가 설정되지 않았습니다.')
+  }
+
+  return apiBaseUrl
+}
+
+function getProfilePath() {
+  return import.meta.env.VITE_PROFILE_ME_PATH || DEFAULT_PROFILE_PATH
+}
+
+function getProfileUpdatePath() {
+  return import.meta.env.VITE_PROFILE_UPDATE_PATH || getProfilePath()
+}
+
+function getProfileUpdateMethod() {
+  const method = (import.meta.env.VITE_PROFILE_UPDATE_METHOD || 'PATCH').toUpperCase()
+  return method === 'PUT' ? 'PUT' : 'PATCH'
+}
+
+function getAuthToken() {
+  const token = localStorage.getItem(AUTH_STORAGE_KEY.ACCESS_TOKEN)
+  if (!token) {
+    throw new Error(PROFILE_ERROR_MESSAGE.UNAUTHORIZED)
+  }
+  return token
+}
+
+function normalizeProfile(raw = {}) {
+  return {
+    email: raw.email ?? '',
+    displayName: raw.displayName ?? raw.name ?? raw.nickname ?? '',
+    phoneNumber: raw.phoneNumber ?? raw.phone ?? raw.mobile ?? '',
+  }
+}
+
+function buildProfileUpdatePayload({ displayName, phoneNumber }) {
+  const nameKey = import.meta.env.VITE_PROFILE_NAME_KEY || 'displayName'
+  const phoneKey = import.meta.env.VITE_PROFILE_PHONE_KEY || 'phoneNumber'
+  const payload = {}
+
+  if (displayName !== undefined) {
+    payload[nameKey] = displayName
+  }
+
+  if (phoneNumber !== undefined) {
+    payload[phoneKey] = phoneNumber
+  }
+
+  return payload
+}
+
+async function requestJson(path, options = {}) {
+  const {
+    method = 'GET',
+    payload,
+    fallbackMessage = ERROR_MESSAGE.DEFAULT,
+    statusMap = {},
+    codeMap = {},
+  } = options
+
+  const abortController = new AbortController()
+  const timeoutId = window.setTimeout(() => abortController.abort(), REQUEST_TIMEOUT_MS)
+
+  let response
+  try {
+    response = await fetch(`${getApiBaseUrl()}${path}`, {
+      method,
+      headers: {
+        Accept: '*/*',
+        Authorization: `Bearer ${getAuthToken()}`,
+        ...(payload ? { 'Content-Type': 'application/json' } : {}),
+      },
+      body: payload ? JSON.stringify(payload) : undefined,
+      signal: abortController.signal,
+    })
+  } catch (error) {
+    const networkMessage =
+      error?.name === 'AbortError' ? ERROR_MESSAGE.TIMEOUT : ERROR_MESSAGE.NETWORK
+    throw new Error(networkMessage, { cause: error })
+  } finally {
+    window.clearTimeout(timeoutId)
+  }
+
+  let data = null
+  try {
+    data = await response.json()
+  } catch {
+    // 빈 응답 본문은 허용합니다.
+  }
+
+  if (!response.ok || data?.isSuccess === false) {
+    const error = new Error(
+      getErrorMessage({
+        status: response.status,
+        code: data?.code,
+        message: data?.message,
+        fallbackMessage,
+        statusMap,
+        codeMap,
+      }),
+    )
+    error.status = response.status
+    error.code = data?.code
+    throw error
+  }
+
+  return data?.result ?? data ?? {}
+}
+
+export async function getMyProfile() {
+  const profile = await requestJson(getProfilePath(), {
+    method: 'GET',
+    fallbackMessage: PROFILE_ERROR_MESSAGE.LOAD_FAILED,
+    statusMap: {
+      401: PROFILE_ERROR_MESSAGE.UNAUTHORIZED,
+    },
+    codeMap: {
+      COMMON401_1: PROFILE_ERROR_MESSAGE.UNAUTHORIZED,
+    },
+  })
+
+  return normalizeProfile(profile)
+}
+
+export async function updateMyProfile({ displayName, phoneNumber }) {
+  const payload = buildProfileUpdatePayload({ displayName, phoneNumber })
+
+  const updatedProfile = await requestJson(getProfileUpdatePath(), {
+    method: getProfileUpdateMethod(),
+    payload,
+    fallbackMessage: PROFILE_ERROR_MESSAGE.UPDATE_FAILED,
+    statusMap: {
+      401: PROFILE_ERROR_MESSAGE.UNAUTHORIZED,
+    },
+    codeMap: {
+      COMMON401_1: PROFILE_ERROR_MESSAGE.UNAUTHORIZED,
+    },
+  })
+
+  if (updatedProfile && Object.keys(updatedProfile).length > 0) {
+    return normalizeProfile(updatedProfile)
+  }
+
+  return normalizeProfile({ displayName, phoneNumber })
+}

--- a/src/components/My/MyMenuRow.jsx
+++ b/src/components/My/MyMenuRow.jsx
@@ -1,0 +1,35 @@
+import { IoChevronForward } from 'react-icons/io5'
+import {
+  MenuRowButton,
+  MenuRowIconWrap,
+  MenuRowLabel,
+  MenuRowLeft,
+  MenuRowRight,
+} from './MyMenuRow.styles'
+
+export default function MyMenuRow({
+  icon: Icon,
+  label,
+  danger = false,
+  onClick,
+  showChevron = true,
+}) {
+  return (
+    <MenuRowButton type="button" onClick={onClick}>
+      <MenuRowLeft>
+        {Icon ? (
+          <MenuRowIconWrap>
+            <Icon size={20} />
+          </MenuRowIconWrap>
+        ) : null}
+        <MenuRowLabel $danger={danger}>{label}</MenuRowLabel>
+      </MenuRowLeft>
+
+      {showChevron ? (
+        <MenuRowRight>
+          <IoChevronForward size={20} />
+        </MenuRowRight>
+      ) : null}
+    </MenuRowButton>
+  )
+}

--- a/src/components/My/MyMenuRow.styles.js
+++ b/src/components/My/MyMenuRow.styles.js
@@ -1,0 +1,46 @@
+import styled from 'styled-components'
+
+export const MenuRowButton = styled.button`
+  width: 100%;
+  min-height: 49px;
+  padding: var(--space-12) 0;
+  border: none;
+  border-bottom: var(--size-1) solid var(--gray-100);
+  background: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-family: var(--font-sans);
+  cursor: pointer;
+`
+
+export const MenuRowLeft = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-12);
+  min-width: 0;
+`
+
+export const MenuRowLabel = styled.span`
+  color: ${({ $danger }) => ($danger ? 'var(--red-500)' : 'var(--black-950)')};
+  font-size: var(--text-16);
+  line-height: var(--line-24);
+  font-weight: ${({ $danger }) => ($danger ? 'var(--fw-medium)' : '400')};
+`
+
+export const MenuRowRight = styled.span`
+  color: var(--gray-400);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+`
+
+export const MenuRowIconWrap = styled.span`
+  width: var(--size-20);
+  height: var(--size-20);
+  color: var(--black-950);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+`

--- a/src/components/My/RatingStars.jsx
+++ b/src/components/My/RatingStars.jsx
@@ -1,0 +1,15 @@
+import { IoStar, IoStarOutline } from 'react-icons/io5'
+import { DateText, Stars } from './RatingStars.styles'
+
+export default function RatingStars({ rating = 0, date }) {
+  const normalized = Math.max(0, Math.min(5, Number(rating) || 0))
+
+  return (
+    <Stars>
+      {Array.from({ length: 5 }).map((_, idx) =>
+        idx < normalized ? <IoStar key={idx} size={16} /> : <IoStarOutline key={idx} size={16} />,
+      )}
+      {date ? <DateText>{date}</DateText> : null}
+    </Stars>
+  )
+}

--- a/src/components/My/RatingStars.styles.js
+++ b/src/components/My/RatingStars.styles.js
@@ -1,0 +1,15 @@
+import styled from 'styled-components'
+
+export const Stars = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-4);
+  color: var(--yellow-500);
+`
+
+export const DateText = styled.span`
+  margin-left: var(--space-8);
+  color: var(--gray-500);
+  font-size: var(--text-14);
+  line-height: var(--line-20);
+`

--- a/src/constants/errorMessages.js
+++ b/src/constants/errorMessages.js
@@ -18,3 +18,9 @@ export const PLACE_ERROR_MESSAGE = {
   SEARCH_FAILED: '검색 결과를 불러오지 못했습니다.',
   SUGGEST_FAILED: '자동완성 결과를 불러오지 못했습니다.',
 }
+
+export const PROFILE_ERROR_MESSAGE = {
+  UNAUTHORIZED: '로그인이 필요합니다. 다시 로그인해 주세요.',
+  LOAD_FAILED: '프로필 정보를 불러오지 못했습니다.',
+  UPDATE_FAILED: '프로필 정보를 저장하지 못했습니다.',
+}

--- a/src/mocks/my/myPage.mock.js
+++ b/src/mocks/my/myPage.mock.js
@@ -1,0 +1,51 @@
+export const mockMyProfile = {
+  email: 'user@example.com',
+  roleLabel: '일반 회원',
+  name: '홍길동',
+  phone: '010-1234-5678',
+}
+
+export const mockFavorites = [
+  {
+    id: 'fav-eng',
+    name: '공학관',
+    address: '서울시 관악구 관악로 1',
+    isRegistered: true,
+  },
+  {
+    id: 'fav-601',
+    name: '601호 강의실',
+    address: '공학관 6층',
+    isRegistered: true,
+  },
+  {
+    id: 'fav-lib',
+    name: '중앙도서관',
+    address: '서울시 관악구 관악로 2',
+    isRegistered: true,
+  },
+]
+
+export const mockMyReviews = [
+  {
+    id: 'review-1',
+    placeName: '공학관',
+    rating: 5,
+    date: '2026-04-20',
+    content: '시설이 깨끗하고 찾기 쉬워요!',
+  },
+  {
+    id: 'review-2',
+    placeName: '중앙도서관',
+    rating: 4,
+    date: '2026-04-18',
+    content: '조용하고 공부하기 좋아요. 다만 주말엔 사람이 많아요.',
+  },
+  {
+    id: 'review-3',
+    placeName: '학생회관',
+    rating: 3,
+    date: '2026-04-15',
+    content: '음식이 괜찮지만 가격이 조금 비싼 편입니다.',
+  },
+]

--- a/src/pages/MapPage/MapPage.jsx
+++ b/src/pages/MapPage/MapPage.jsx
@@ -149,7 +149,12 @@ export default function MapPage() {
       return
     }
 
-    setCurrentNav(key)
+    if (key === 'my') {
+      navigate('/my')
+      return
+    }
+
+    setCurrentNav('map')
   }
 
   const handleCurrentLocationSelect = ({ lat, lng }) => {

--- a/src/pages/MyPage/FavoritesPage/FavoritesPage.css
+++ b/src/pages/MyPage/FavoritesPage/FavoritesPage.css
@@ -1,0 +1,72 @@
+.favorites-page {
+  min-height: 100dvh;
+  background: var(--surface-0);
+  padding-bottom: calc(88px + env(safe-area-inset-bottom));
+}
+
+.favorites-page__list {
+  padding: var(--space-12) var(--space-16) 0;
+}
+
+.favorite-item {
+  width: 100%;
+  border: none;
+  border-bottom: var(--size-1) solid var(--gray-100);
+  background: transparent;
+  padding: var(--space-12) 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-12);
+  cursor: pointer;
+  text-align: left;
+}
+
+.favorite-item__content {
+  min-width: 0;
+  flex: 1;
+}
+
+.favorite-item__title-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+}
+
+.favorite-item__title-row strong {
+  color: var(--black-950);
+  font-size: var(--text-16);
+  line-height: var(--line-24);
+  font-weight: var(--fw-medium);
+}
+
+.favorite-item__title-row span {
+  padding: var(--space-2) var(--space-8);
+  border-radius: var(--radius-4);
+  background: var(--blue-100);
+  color: var(--blue-600);
+  font-size: var(--text-12);
+  line-height: var(--line-16);
+}
+
+.favorite-item__content p {
+  margin: var(--space-4) 0 0;
+  color: var(--gray-500);
+  font-size: var(--text-14);
+  line-height: var(--line-20);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.favorite-item__right {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-8);
+  color: var(--gray-400);
+  flex-shrink: 0;
+}
+
+.favorite-item__right svg:first-child {
+  color: var(--yellow-500);
+}

--- a/src/pages/MyPage/FavoritesPage/FavoritesPage.jsx
+++ b/src/pages/MyPage/FavoritesPage/FavoritesPage.jsx
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router-dom'
 import { IoChevronForward, IoStar } from 'react-icons/io5'
 import BottomNav from '../../../components/BottomNav/BottomNav'
 import CommonHeader from '../../../components/CommonHeader/CommonHeader'
+import { ROUTES } from '../../../constants/routes'
 import { mockFavorites } from '../../../mocks/my/myPage.mock'
 import getBottomNavRoute from '../../../utils/navigation/bottomNavRoute'
 import './FavoritesPage.css'
@@ -13,13 +14,33 @@ export default function FavoritesPage() {
     navigate(getBottomNavRoute(key))
   }
 
+  const handleSelectFavorite = (item) => {
+    navigate(ROUTES.MAP, {
+      state: {
+        selectedSearchPlace: {
+          id: item.id,
+          title: item.name,
+          name: item.name,
+          address: item.address,
+          isRegistered: item.isRegistered,
+        },
+        openSheetFrom: 'search-result',
+      },
+    })
+  }
+
   return (
     <main className="favorites-page">
       <CommonHeader variant="title" title="즐겨찾기" onBack={() => navigate('/my')} />
 
       <section className="favorites-page__list" aria-label="즐겨찾기 목록">
         {mockFavorites.map((item) => (
-          <button key={item.id} type="button" className="favorite-item">
+          <button
+            key={item.id}
+            type="button"
+            className="favorite-item"
+            onClick={() => handleSelectFavorite(item)}
+          >
             <div className="favorite-item__content">
               <div className="favorite-item__title-row">
                 <strong>{item.name}</strong>

--- a/src/pages/MyPage/FavoritesPage/FavoritesPage.jsx
+++ b/src/pages/MyPage/FavoritesPage/FavoritesPage.jsx
@@ -1,0 +1,42 @@
+import { useNavigate } from 'react-router-dom'
+import { IoChevronForward, IoStar } from 'react-icons/io5'
+import BottomNav from '../../../components/BottomNav/BottomNav'
+import CommonHeader from '../../../components/CommonHeader/CommonHeader'
+import { mockFavorites } from '../../../mocks/my/myPage.mock'
+import getBottomNavRoute from '../../../utils/navigation/bottomNavRoute'
+import './FavoritesPage.css'
+
+export default function FavoritesPage() {
+  const navigate = useNavigate()
+
+  const handleBottomNavChange = (key) => {
+    navigate(getBottomNavRoute(key))
+  }
+
+  return (
+    <main className="favorites-page">
+      <CommonHeader variant="title" title="즐겨찾기" onBack={() => navigate('/my')} />
+
+      <section className="favorites-page__list" aria-label="즐겨찾기 목록">
+        {mockFavorites.map((item) => (
+          <button key={item.id} type="button" className="favorite-item">
+            <div className="favorite-item__content">
+              <div className="favorite-item__title-row">
+                <strong>{item.name}</strong>
+                {item.isRegistered ? <span>등록됨</span> : null}
+              </div>
+              <p>{item.address}</p>
+            </div>
+
+            <div className="favorite-item__right">
+              <IoStar size={18} />
+              <IoChevronForward size={20} />
+            </div>
+          </button>
+        ))}
+      </section>
+
+      <BottomNav currentKey="my" onChange={handleBottomNavChange} />
+    </main>
+  )
+}

--- a/src/pages/MyPage/MyPage/MyPage.css
+++ b/src/pages/MyPage/MyPage/MyPage.css
@@ -1,0 +1,77 @@
+.my-page {
+  min-height: 100dvh;
+  background: var(--surface-0);
+  padding-bottom: calc(88px + env(safe-area-inset-bottom));
+}
+
+.my-page__header {
+  min-height: 61px;
+  padding: var(--space-16);
+  border-bottom: var(--size-1) solid var(--gray-200);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.my-page__header h1 {
+  margin: 0;
+  color: var(--black-950);
+  font-size: var(--text-20);
+  line-height: 1.75rem;
+  font-weight: var(--fw-medium);
+}
+
+.my-page__profile {
+  min-height: 113px;
+  padding: var(--space-24) var(--space-16) var(--space-16);
+  border-bottom: var(--size-1) solid var(--gray-200);
+  display: flex;
+  align-items: center;
+  gap: var(--space-16);
+}
+
+.my-page__avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 999px;
+  background: var(--gray-200);
+  color: var(--gray-500);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.my-page__profile-text {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  min-width: 0;
+}
+
+.my-page__profile-text strong {
+  color: var(--black-950);
+  font-size: var(--text-16);
+  line-height: var(--line-24);
+  font-weight: var(--fw-medium);
+  word-break: break-all;
+}
+
+.my-page__profile-text span {
+  color: var(--gray-500);
+  font-size: var(--text-14);
+  line-height: var(--line-20);
+}
+
+.my-page__menu {
+  padding: var(--space-16);
+}
+
+.my-page__logout {
+  padding: 0 var(--space-16);
+}
+
+.my-page__logout button {
+  color: var(--gray-600);
+  font-weight: var(--fw-medium);
+}

--- a/src/pages/MyPage/MyPage/MyPage.jsx
+++ b/src/pages/MyPage/MyPage/MyPage.jsx
@@ -1,22 +1,48 @@
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
   IoChatbubbleEllipsesOutline,
   IoHeartOutline,
   IoPersonOutline,
 } from 'react-icons/io5'
+import { getMyProfile } from '../../../apis/profileApi'
 import BottomNav from '../../../components/BottomNav/BottomNav'
 import Button from '../../../components/Button/Button'
 import MyMenuRow from '../../../components/My/MyMenuRow'
-import { mockMyProfile } from '../../../mocks/my/myPage.mock'
 import getBottomNavRoute from '../../../utils/navigation/bottomNavRoute'
 import './MyPage.css'
 
 export default function MyPage() {
   const navigate = useNavigate()
+  const [displayName, setDisplayName] = useState('')
+  const [email, setEmail] = useState('')
 
   const handleBottomNavChange = (key) => {
     navigate(getBottomNavRoute(key))
   }
+
+  useEffect(() => {
+    let isMounted = true
+
+    async function loadProfileSummary() {
+      try {
+        const profile = await getMyProfile()
+        if (!isMounted) return
+        setDisplayName(profile.displayName)
+        setEmail(profile.email)
+      } catch {
+        if (!isMounted) return
+        setDisplayName('')
+        setEmail('')
+      }
+    }
+
+    loadProfileSummary()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
 
   return (
     <main className="my-page">
@@ -29,8 +55,8 @@ export default function MyPage() {
           <IoPersonOutline size={32} />
         </div>
         <div className="my-page__profile-text">
-          <strong>{mockMyProfile.email}</strong>
-          <span>{mockMyProfile.roleLabel}</span>
+          <strong>{displayName || email || '-'}</strong>
+          <span>{email || '이메일 정보 없음'}</span>
         </div>
       </section>
 

--- a/src/pages/MyPage/MyPage/MyPage.jsx
+++ b/src/pages/MyPage/MyPage/MyPage.jsx
@@ -9,6 +9,7 @@ import { getMyProfile } from '../../../apis/profileApi'
 import BottomNav from '../../../components/BottomNav/BottomNav'
 import Button from '../../../components/Button/Button'
 import MyMenuRow from '../../../components/My/MyMenuRow'
+import { AUTH_STORAGE_KEY } from '../../../constants/auth'
 import getBottomNavRoute from '../../../utils/navigation/bottomNavRoute'
 import './MyPage.css'
 
@@ -16,6 +17,7 @@ export default function MyPage() {
   const navigate = useNavigate()
   const [displayName, setDisplayName] = useState('')
   const [email, setEmail] = useState('')
+  const [isLoggedIn, setIsLoggedIn] = useState(false)
 
   const handleBottomNavChange = (key) => {
     navigate(getBottomNavRoute(key))
@@ -25,13 +27,25 @@ export default function MyPage() {
     let isMounted = true
 
     async function loadProfileSummary() {
+      const token = localStorage.getItem(AUTH_STORAGE_KEY.ACCESS_TOKEN)
+
+      if (!token) {
+        if (!isMounted) return
+        setIsLoggedIn(false)
+        setDisplayName('')
+        setEmail('')
+        return
+      }
+
       try {
         const profile = await getMyProfile()
         if (!isMounted) return
+        setIsLoggedIn(true)
         setDisplayName(profile.displayName)
         setEmail(profile.email)
       } catch {
         if (!isMounted) return
+        setIsLoggedIn(false)
         setDisplayName('')
         setEmail('')
       }
@@ -44,6 +58,27 @@ export default function MyPage() {
     }
   }, [])
 
+  const handleProtectedNavigation = (path) => {
+    if (!isLoggedIn) {
+      navigate('/login')
+      return
+    }
+    navigate(path)
+  }
+
+  const handleAuthAction = () => {
+    if (!isLoggedIn) {
+      navigate('/login')
+      return
+    }
+
+    localStorage.removeItem(AUTH_STORAGE_KEY.ACCESS_TOKEN)
+    setIsLoggedIn(false)
+    setDisplayName('')
+    setEmail('')
+    navigate('/login', { replace: true })
+  }
+
   return (
     <main className="my-page">
       <header className="my-page__header">
@@ -55,8 +90,12 @@ export default function MyPage() {
           <IoPersonOutline size={32} />
         </div>
         <div className="my-page__profile-text">
-          <strong>{displayName || email || '-'}</strong>
-          <span>{email || '이메일 정보 없음'}</span>
+          <strong>{isLoggedIn ? displayName || email : '로그인이 필요해요'}</strong>
+          <span>
+            {isLoggedIn
+              ? email || '이메일 정보 없음'
+              : '로그인하면 즐겨찾기와 내가 쓴 리뷰를 확인할 수 있어요'}
+          </span>
         </div>
       </section>
 
@@ -64,18 +103,20 @@ export default function MyPage() {
         <MyMenuRow
           icon={IoHeartOutline}
           label="즐겨찾기"
-          onClick={() => navigate('/my/favorites')}
+          onClick={() => handleProtectedNavigation('/my/favorites')}
         />
         <MyMenuRow
           icon={IoChatbubbleEllipsesOutline}
           label="내가 쓴 리뷰"
-          onClick={() => navigate('/my/reviews')}
+          onClick={() => handleProtectedNavigation('/my/reviews')}
         />
-        <MyMenuRow label="설정" onClick={() => navigate('/my/settings')} />
+        <MyMenuRow label="설정" onClick={() => handleProtectedNavigation('/my/settings')} />
       </section>
 
       <div className="my-page__logout">
-        <Button variant="outline">로그아웃</Button>
+        <Button variant="outline" onClick={handleAuthAction}>
+          {isLoggedIn ? '로그아웃' : '로그인'}
+        </Button>
       </div>
 
       <BottomNav currentKey="my" onChange={handleBottomNavChange} />

--- a/src/pages/MyPage/MyPage/MyPage.jsx
+++ b/src/pages/MyPage/MyPage/MyPage.jsx
@@ -94,7 +94,7 @@ export default function MyPage() {
           <span>
             {isLoggedIn
               ? email || '이메일 정보 없음'
-              : '로그인하면 즐겨찾기와 내가 쓴 리뷰를 확인할 수 있어요'}
+              : '로그인하면 즐겨찾기/리뷰를 확인할 수 있어요.'}
           </span>
         </div>
       </section>

--- a/src/pages/MyPage/MyPage/MyPage.jsx
+++ b/src/pages/MyPage/MyPage/MyPage.jsx
@@ -1,0 +1,58 @@
+import { useNavigate } from 'react-router-dom'
+import {
+  IoChatbubbleEllipsesOutline,
+  IoHeartOutline,
+  IoPersonOutline,
+} from 'react-icons/io5'
+import BottomNav from '../../../components/BottomNav/BottomNav'
+import Button from '../../../components/Button/Button'
+import MyMenuRow from '../../../components/My/MyMenuRow'
+import { mockMyProfile } from '../../../mocks/my/myPage.mock'
+import getBottomNavRoute from '../../../utils/navigation/bottomNavRoute'
+import './MyPage.css'
+
+export default function MyPage() {
+  const navigate = useNavigate()
+
+  const handleBottomNavChange = (key) => {
+    navigate(getBottomNavRoute(key))
+  }
+
+  return (
+    <main className="my-page">
+      <header className="my-page__header">
+        <h1>마이페이지</h1>
+      </header>
+
+      <section className="my-page__profile" aria-label="프로필 요약">
+        <div className="my-page__avatar">
+          <IoPersonOutline size={32} />
+        </div>
+        <div className="my-page__profile-text">
+          <strong>{mockMyProfile.email}</strong>
+          <span>{mockMyProfile.roleLabel}</span>
+        </div>
+      </section>
+
+      <section className="my-page__menu" aria-label="마이 메뉴">
+        <MyMenuRow
+          icon={IoHeartOutline}
+          label="즐겨찾기"
+          onClick={() => navigate('/my/favorites')}
+        />
+        <MyMenuRow
+          icon={IoChatbubbleEllipsesOutline}
+          label="내가 쓴 리뷰"
+          onClick={() => navigate('/my/reviews')}
+        />
+        <MyMenuRow label="설정" onClick={() => navigate('/my/settings')} />
+      </section>
+
+      <div className="my-page__logout">
+        <Button variant="outline">로그아웃</Button>
+      </div>
+
+      <BottomNav currentKey="my" onChange={handleBottomNavChange} />
+    </main>
+  )
+}

--- a/src/pages/MyPage/PasswordPage/PasswordPage.css
+++ b/src/pages/MyPage/PasswordPage/PasswordPage.css
@@ -1,0 +1,20 @@
+.password-page {
+  min-height: 100dvh;
+  background: var(--surface-0);
+  padding-bottom: calc(88px + env(safe-area-inset-bottom));
+}
+
+.password-page__content {
+  padding: var(--space-24) var(--space-16) 0;
+  display: grid;
+  gap: var(--space-24);
+}
+
+.password-page__hint {
+  padding: var(--space-12) var(--space-16);
+  border-radius: var(--radius-10);
+  background: var(--blue-50);
+  color: var(--blue-900);
+  font-size: var(--text-14);
+  line-height: var(--line-20);
+}

--- a/src/pages/MyPage/PasswordPage/PasswordPage.jsx
+++ b/src/pages/MyPage/PasswordPage/PasswordPage.jsx
@@ -1,0 +1,68 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import BottomNav from '../../../components/BottomNav/BottomNav'
+import Button from '../../../components/Button/Button'
+import CommonHeader from '../../../components/CommonHeader/CommonHeader'
+import Input from '../../../components/Input/Input'
+import getBottomNavRoute from '../../../utils/navigation/bottomNavRoute'
+import './PasswordPage.css'
+
+export default function PasswordPage() {
+  const navigate = useNavigate()
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+
+  const handleBottomNavChange = (key) => {
+    navigate(getBottomNavRoute(key))
+  }
+
+  return (
+    <main className="password-page">
+      <CommonHeader
+        variant="title"
+        title="비밀번호 변경"
+        onBack={() => navigate('/my/settings')}
+      />
+
+      <section className="password-page__content">
+        <div className="password-page__form">
+          <Input
+            id="current-password"
+            type="password"
+            label="현재 비밀번호"
+            value={currentPassword}
+            onChange={(event) => setCurrentPassword(event.target.value)}
+            placeholder="현재 비밀번호 입력"
+          />
+
+          <Input
+            id="new-password"
+            type="password"
+            label="새 비밀번호"
+            value={newPassword}
+            onChange={(event) => setNewPassword(event.target.value)}
+            placeholder="새 비밀번호 입력 (8자 이상)"
+          />
+
+          <Input
+            id="confirm-password"
+            type="password"
+            label="새 비밀번호 확인"
+            value={confirmPassword}
+            onChange={(event) => setConfirmPassword(event.target.value)}
+            placeholder="새 비밀번호 재입력"
+          />
+
+          <Button>변경하기</Button>
+        </div>
+
+        <div className="password-page__hint">
+          비밀번호는 영문 대소문자, 숫자, 특수문자를 포함해 8자 이상으로 설정해 주세요.
+        </div>
+      </section>
+
+      <BottomNav currentKey="my" onChange={handleBottomNavChange} />
+    </main>
+  )
+}

--- a/src/pages/MyPage/ProfilePage/ProfilePage.css
+++ b/src/pages/MyPage/ProfilePage/ProfilePage.css
@@ -55,3 +55,17 @@
   font-size: var(--text-12);
   line-height: var(--line-16);
 }
+
+.profile-page__status {
+  margin: 0 0 var(--space-12);
+  font-size: var(--text-14);
+  line-height: var(--line-20);
+}
+
+.profile-page__status--error {
+  color: var(--red-500);
+}
+
+.profile-page__status--success {
+  color: var(--blue-700);
+}

--- a/src/pages/MyPage/ProfilePage/ProfilePage.css
+++ b/src/pages/MyPage/ProfilePage/ProfilePage.css
@@ -1,0 +1,57 @@
+.profile-page {
+  min-height: 100dvh;
+  background: var(--surface-0);
+  padding-bottom: calc(88px + env(safe-area-inset-bottom));
+}
+
+.profile-page__content {
+  padding: var(--space-24) var(--space-16) 0;
+}
+
+.profile-page__avatar {
+  width: 96px;
+  height: 96px;
+  margin: 0 auto;
+  border-radius: 999px;
+  background: var(--gray-200);
+  color: var(--gray-500);
+  display: grid;
+  place-items: center;
+}
+
+.profile-page__form {
+  margin-top: var(--space-24);
+}
+
+.profile-page__readonly {
+  margin-bottom: var(--space-16);
+}
+
+.profile-page__label {
+  margin: 0 0 var(--space-8);
+  color: var(--gray-600);
+  font-size: var(--text-14);
+  line-height: var(--line-20);
+  font-weight: var(--fw-medium);
+}
+
+.profile-page__email-box {
+  min-height: 50px;
+  padding: var(--space-12) var(--space-16);
+  border-radius: var(--radius-10);
+  border: var(--size-1) solid var(--gray-200);
+  background: var(--surface-50);
+  color: var(--gray-500);
+  font-size: var(--text-16);
+  line-height: var(--line-24);
+  display: flex;
+  align-items: center;
+}
+
+.profile-page__readonly small {
+  margin-top: var(--space-4);
+  display: block;
+  color: var(--gray-500);
+  font-size: var(--text-12);
+  line-height: var(--line-16);
+}

--- a/src/pages/MyPage/ProfilePage/ProfilePage.jsx
+++ b/src/pages/MyPage/ProfilePage/ProfilePage.jsx
@@ -1,0 +1,66 @@
+import { useState } from 'react'
+import { IoPersonOutline } from 'react-icons/io5'
+import { useNavigate } from 'react-router-dom'
+import BottomNav from '../../../components/BottomNav/BottomNav'
+import Button from '../../../components/Button/Button'
+import CommonHeader from '../../../components/CommonHeader/CommonHeader'
+import Input from '../../../components/Input/Input'
+import { mockMyProfile } from '../../../mocks/my/myPage.mock'
+import getBottomNavRoute from '../../../utils/navigation/bottomNavRoute'
+import './ProfilePage.css'
+
+export default function ProfilePage() {
+  const navigate = useNavigate()
+  const [name, setName] = useState(mockMyProfile.name)
+  const [phone, setPhone] = useState(mockMyProfile.phone)
+
+  const handleBottomNavChange = (key) => {
+    navigate(getBottomNavRoute(key))
+  }
+
+  return (
+    <main className="profile-page">
+      <CommonHeader
+        variant="title"
+        title="프로필 정보"
+        onBack={() => navigate('/my/settings')}
+      />
+
+      <section className="profile-page__content">
+        <div className="profile-page__avatar" aria-hidden="true">
+          <IoPersonOutline size={48} />
+        </div>
+
+        <div className="profile-page__form">
+          <div className="profile-page__readonly">
+            <p className="profile-page__label">이메일</p>
+            <div className="profile-page__email-box">{mockMyProfile.email}</div>
+            <small>이메일은 변경할 수 없습니다</small>
+          </div>
+
+          <Input
+            id="profile-name"
+            label="이름"
+            value={name}
+            maxLength={10}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="이름을 입력하세요"
+          />
+
+          <Input
+            id="profile-phone"
+            label="전화번호"
+            subLabel="선택"
+            value={phone}
+            onChange={(event) => setPhone(event.target.value)}
+            placeholder="010-0000-0000"
+          />
+
+          <Button>저장</Button>
+        </div>
+      </section>
+
+      <BottomNav currentKey="my" onChange={handleBottomNavChange} />
+    </main>
+  )
+}

--- a/src/pages/MyPage/ProfilePage/ProfilePage.jsx
+++ b/src/pages/MyPage/ProfilePage/ProfilePage.jsx
@@ -1,21 +1,77 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { IoPersonOutline } from 'react-icons/io5'
 import { useNavigate } from 'react-router-dom'
+import { getMyProfile, updateMyProfile } from '../../../apis/profileApi'
 import BottomNav from '../../../components/BottomNav/BottomNav'
 import Button from '../../../components/Button/Button'
 import CommonHeader from '../../../components/CommonHeader/CommonHeader'
 import Input from '../../../components/Input/Input'
-import { mockMyProfile } from '../../../mocks/my/myPage.mock'
 import getBottomNavRoute from '../../../utils/navigation/bottomNavRoute'
 import './ProfilePage.css'
 
 export default function ProfilePage() {
   const navigate = useNavigate()
-  const [name, setName] = useState(mockMyProfile.name)
-  const [phone, setPhone] = useState(mockMyProfile.phone)
+  const [email, setEmail] = useState('')
+  const [name, setName] = useState('')
+  const [phone, setPhone] = useState('')
+  const [isLoading, setIsLoading] = useState(true)
+  const [isSaving, setIsSaving] = useState(false)
+  const [serverError, setServerError] = useState('')
+  const [successMessage, setSuccessMessage] = useState('')
 
   const handleBottomNavChange = (key) => {
     navigate(getBottomNavRoute(key))
+  }
+
+  useEffect(() => {
+    let isMounted = true
+
+    async function loadProfile() {
+      setIsLoading(true)
+      setServerError('')
+
+      try {
+        const profile = await getMyProfile()
+        if (!isMounted) return
+
+        setEmail(profile.email)
+        setName(profile.displayName)
+        setPhone(profile.phoneNumber)
+      } catch (error) {
+        if (!isMounted) return
+        setServerError(error.message)
+      } finally {
+        if (isMounted) setIsLoading(false)
+      }
+    }
+
+    loadProfile()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  const handleSubmit = async (event) => {
+    event.preventDefault()
+    setServerError('')
+    setSuccessMessage('')
+    setIsSaving(true)
+
+    try {
+      const updatedProfile = await updateMyProfile({
+        displayName: name.trim(),
+        phoneNumber: phone.trim(),
+      })
+      setEmail(updatedProfile.email || email)
+      setName(updatedProfile.displayName)
+      setPhone(updatedProfile.phoneNumber)
+      setSuccessMessage('프로필 정보가 저장되었습니다.')
+    } catch (error) {
+      setServerError(error.message)
+    } finally {
+      setIsSaving(false)
+    }
   }
 
   return (
@@ -31,10 +87,10 @@ export default function ProfilePage() {
           <IoPersonOutline size={48} />
         </div>
 
-        <div className="profile-page__form">
+        <form className="profile-page__form" onSubmit={handleSubmit}>
           <div className="profile-page__readonly">
             <p className="profile-page__label">이메일</p>
-            <div className="profile-page__email-box">{mockMyProfile.email}</div>
+            <div className="profile-page__email-box">{email || '-'}</div>
             <small>이메일은 변경할 수 없습니다</small>
           </div>
 
@@ -45,6 +101,7 @@ export default function ProfilePage() {
             maxLength={10}
             onChange={(event) => setName(event.target.value)}
             placeholder="이름을 입력하세요"
+            disabled={isLoading || isSaving}
           />
 
           <Input
@@ -54,10 +111,24 @@ export default function ProfilePage() {
             value={phone}
             onChange={(event) => setPhone(event.target.value)}
             placeholder="010-0000-0000"
+            disabled={isLoading || isSaving}
           />
 
-          <Button>저장</Button>
-        </div>
+          {serverError ? (
+            <p className="profile-page__status profile-page__status--error">
+              {serverError}
+            </p>
+          ) : null}
+          {successMessage ? (
+            <p className="profile-page__status profile-page__status--success">
+              {successMessage}
+            </p>
+          ) : null}
+
+          <Button type="submit" disabled={isLoading || isSaving}>
+            {isSaving ? '저장 중...' : '저장'}
+          </Button>
+        </form>
       </section>
 
       <BottomNav currentKey="my" onChange={handleBottomNavChange} />

--- a/src/pages/MyPage/ProfilePage/ProfilePage.jsx
+++ b/src/pages/MyPage/ProfilePage/ProfilePage.jsx
@@ -64,8 +64,8 @@ export default function ProfilePage() {
         phoneNumber: phone.trim(),
       })
       setEmail(updatedProfile.email || email)
-      setName(updatedProfile.displayName)
-      setPhone(updatedProfile.phoneNumber)
+      setName(updatedProfile.displayName || name)
+      setPhone(updatedProfile.phoneNumber || phone)
       setSuccessMessage('프로필 정보가 저장되었습니다.')
     } catch (error) {
       setServerError(error.message)

--- a/src/pages/MyPage/ReviewsPage/ReviewsPage.css
+++ b/src/pages/MyPage/ReviewsPage/ReviewsPage.css
@@ -1,0 +1,46 @@
+.reviews-page {
+  min-height: 100dvh;
+  background: var(--surface-0);
+  padding-bottom: calc(88px + env(safe-area-inset-bottom));
+}
+
+.reviews-page__list {
+  padding: var(--space-12) var(--space-16) 0;
+}
+
+.review-item {
+  padding: var(--space-16) 0 var(--space-12);
+  border-bottom: var(--size-1) solid var(--gray-100);
+  display: grid;
+  gap: var(--space-8);
+}
+
+.review-item__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.review-item__header strong {
+  color: var(--black-950);
+  font-size: var(--text-16);
+  line-height: var(--line-24);
+  font-weight: var(--fw-medium);
+}
+
+.review-item__header button {
+  border: none;
+  background: transparent;
+  color: var(--red-500);
+  font-size: var(--text-14);
+  line-height: var(--line-20);
+  font-weight: var(--fw-medium);
+  cursor: pointer;
+}
+
+.review-item p {
+  margin: 0;
+  color: var(--gray-700);
+  font-size: var(--text-14);
+  line-height: var(--line-20);
+}

--- a/src/pages/MyPage/ReviewsPage/ReviewsPage.jsx
+++ b/src/pages/MyPage/ReviewsPage/ReviewsPage.jsx
@@ -1,0 +1,38 @@
+import { useNavigate } from 'react-router-dom'
+import BottomNav from '../../../components/BottomNav/BottomNav'
+import CommonHeader from '../../../components/CommonHeader/CommonHeader'
+import RatingStars from '../../../components/My/RatingStars'
+import { mockMyReviews } from '../../../mocks/my/myPage.mock'
+import getBottomNavRoute from '../../../utils/navigation/bottomNavRoute'
+import './ReviewsPage.css'
+
+export default function ReviewsPage() {
+  const navigate = useNavigate()
+
+  const handleBottomNavChange = (key) => {
+    navigate(getBottomNavRoute(key))
+  }
+
+  return (
+    <main className="reviews-page">
+      <CommonHeader variant="title" title="내가 쓴 리뷰" onBack={() => navigate('/my')} />
+
+      <section className="reviews-page__list" aria-label="내가 쓴 리뷰 목록">
+        {mockMyReviews.map((review) => (
+          <article key={review.id} className="review-item">
+            <div className="review-item__header">
+              <strong>{review.placeName}</strong>
+              <button type="button">삭제</button>
+            </div>
+
+            <RatingStars rating={review.rating} date={review.date} />
+
+            <p>{review.content}</p>
+          </article>
+        ))}
+      </section>
+
+      <BottomNav currentKey="my" onChange={handleBottomNavChange} />
+    </main>
+  )
+}

--- a/src/pages/MyPage/ReviewsPage/ReviewsPage.jsx
+++ b/src/pages/MyPage/ReviewsPage/ReviewsPage.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import BottomNav from '../../../components/BottomNav/BottomNav'
 import CommonHeader from '../../../components/CommonHeader/CommonHeader'
@@ -8,9 +9,14 @@ import './ReviewsPage.css'
 
 export default function ReviewsPage() {
   const navigate = useNavigate()
+  const [reviews, setReviews] = useState(mockMyReviews)
 
   const handleBottomNavChange = (key) => {
     navigate(getBottomNavRoute(key))
+  }
+
+  const handleDeleteReview = (reviewId) => {
+    setReviews((prev) => prev.filter((review) => review.id !== reviewId))
   }
 
   return (
@@ -18,11 +24,13 @@ export default function ReviewsPage() {
       <CommonHeader variant="title" title="내가 쓴 리뷰" onBack={() => navigate('/my')} />
 
       <section className="reviews-page__list" aria-label="내가 쓴 리뷰 목록">
-        {mockMyReviews.map((review) => (
+        {reviews.map((review) => (
           <article key={review.id} className="review-item">
             <div className="review-item__header">
               <strong>{review.placeName}</strong>
-              <button type="button">삭제</button>
+              <button type="button" onClick={() => handleDeleteReview(review.id)}>
+                삭제
+              </button>
             </div>
 
             <RatingStars rating={review.rating} date={review.date} />

--- a/src/pages/MyPage/SettingsPage/SettingsPage.css
+++ b/src/pages/MyPage/SettingsPage/SettingsPage.css
@@ -1,0 +1,70 @@
+.settings-page {
+  min-height: 100dvh;
+  background: var(--surface-0);
+  padding-bottom: calc(88px + env(safe-area-inset-bottom));
+}
+
+.settings-page__section {
+  padding: var(--space-16);
+}
+
+.settings-page__section > p {
+  margin: 0;
+  color: var(--gray-500);
+  font-size: var(--text-14);
+  line-height: var(--line-20);
+  font-weight: var(--fw-medium);
+}
+
+.settings-page__menu {
+  margin-top: var(--space-12);
+}
+
+.withdraw-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-items: center;
+  padding: var(--space-16);
+}
+
+.withdraw-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: var(--overlay-dim);
+}
+
+.withdraw-modal__content {
+  position: relative;
+  width: 100%;
+  max-width: 362px;
+  padding: var(--space-24);
+  border-radius: var(--radius-12);
+  background: var(--surface-0);
+}
+
+.withdraw-modal__content h2 {
+  margin: 0;
+  color: var(--black-950);
+  font-size: var(--text-20);
+  line-height: 1.75rem;
+  font-weight: var(--fw-medium);
+}
+
+.withdraw-modal__content p {
+  margin: var(--space-8) 0 0;
+  color: var(--gray-600);
+  font-size: var(--text-16);
+  line-height: var(--line-24);
+}
+
+.withdraw-modal__actions {
+  margin-top: var(--space-24);
+  display: flex;
+  gap: var(--space-12);
+}
+
+.withdraw-modal__actions > div {
+  flex: 1;
+}

--- a/src/pages/MyPage/SettingsPage/SettingsPage.jsx
+++ b/src/pages/MyPage/SettingsPage/SettingsPage.jsx
@@ -1,0 +1,64 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import BottomNav from '../../../components/BottomNav/BottomNav'
+import Button from '../../../components/Button/Button'
+import CommonHeader from '../../../components/CommonHeader/CommonHeader'
+import MyMenuRow from '../../../components/My/MyMenuRow'
+import getBottomNavRoute from '../../../utils/navigation/bottomNavRoute'
+import './SettingsPage.css'
+
+export default function SettingsPage() {
+  const navigate = useNavigate()
+  const [isWithdrawModalOpen, setIsWithdrawModalOpen] = useState(false)
+
+  const handleBottomNavChange = (key) => {
+    navigate(getBottomNavRoute(key))
+  }
+
+  return (
+    <main className="settings-page">
+      <CommonHeader variant="title" title="설정" onBack={() => navigate('/my')} />
+
+      <section className="settings-page__section" aria-label="계정 관리">
+        <p>계정 관리</p>
+
+        <div className="settings-page__menu">
+          <MyMenuRow label="프로필 정보" onClick={() => navigate('/my/profile')} />
+          <MyMenuRow label="비밀번호 변경" onClick={() => navigate('/my/password')} />
+          <MyMenuRow
+            label="회원 탈퇴"
+            danger
+            onClick={() => setIsWithdrawModalOpen(true)}
+          />
+        </div>
+      </section>
+
+      {isWithdrawModalOpen ? (
+        <div className="withdraw-modal" role="dialog" aria-modal="true">
+          <div className="withdraw-modal__backdrop" onClick={() => setIsWithdrawModalOpen(false)} />
+          <div className="withdraw-modal__content">
+            <h2>회원 탈퇴</h2>
+            <p>
+              정말 탈퇴하시겠습니까?
+              <br />
+              모든 데이터가 삭제되며 복구할 수 없습니다.
+            </p>
+
+            <div className="withdraw-modal__actions">
+              <div>
+                <Button variant="outline" onClick={() => setIsWithdrawModalOpen(false)}>
+                  취소
+                </Button>
+              </div>
+              <div>
+                <Button variant="danger">탈퇴하기</Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      <BottomNav currentKey="my" onChange={handleBottomNavChange} />
+    </main>
+  )
+}

--- a/src/pages/RoutingPage/RoutingPage.jsx
+++ b/src/pages/RoutingPage/RoutingPage.jsx
@@ -13,6 +13,7 @@ import SearchInput from '../../components/SearchInput/SearchInput'
 import TransportSelector from '../../components/Transport/TransportSelector'
 import TransitTurnByTurnList from '../../components/NavigationGuidance/TransitTurnByTurnList'
 import TurnByTurnList from '../../components/NavigationGuidance/TurnByTurnList'
+import { ROUTES } from '../../constants/routes'
 import { mockMapPois } from '../../mocks/map/poi.mock'
 import { mockSearchPlaces } from '../../mocks/search/searchPage.mock'
 import isRegisteredPlace from '../../utils/map/isRegisteredPlace'
@@ -186,7 +187,24 @@ export default function RoutingPage() {
       ) : null}
 
       {!guidanceStarted ? (
-        <BottomNav currentKey={currentNav} onChange={routing.setCurrentNav} />
+        <BottomNav
+          currentKey={currentNav}
+          onChange={(key) => {
+            if (key === 'navigation') {
+              routing.setCurrentNav('navigation')
+              return
+            }
+
+            if (key === 'map') {
+              navigate(ROUTES.MAP)
+              return
+            }
+
+            if (key === 'my') {
+              navigate('/my')
+            }
+          }}
+        />
       ) : null}
 
       <MapPoiSheet

--- a/src/pages/RoutingPage/useRoutingController.js
+++ b/src/pages/RoutingPage/useRoutingController.js
@@ -8,7 +8,7 @@ import {
 } from '../../utils/map/navigationPlaceMapper'
 
 export default function useRoutingController() {
-  const [currentNav, setCurrentNav] = useState('navigation')
+const [currentNav, setCurrentNav] = useState('map')
   const [transportMode, setTransportMode] = useState('walk')
   const [routeSheetOpen, setRouteSheetOpen] = useState(false)
   const [guidanceStarted, setGuidanceStarted] = useState(false)

--- a/src/pages/RoutingPage/useRoutingController.js
+++ b/src/pages/RoutingPage/useRoutingController.js
@@ -8,7 +8,7 @@ import {
 } from '../../utils/map/navigationPlaceMapper'
 
 export default function useRoutingController() {
-  const [currentNav, setCurrentNav] = useState('map')
+  const [currentNav, setCurrentNav] = useState('navigation')
   const [transportMode, setTransportMode] = useState('walk')
   const [routeSheetOpen, setRouteSheetOpen] = useState(false)
   const [guidanceStarted, setGuidanceStarted] = useState(false)

--- a/src/pages/RoutingSearchPage/RoutingSearchPage.jsx
+++ b/src/pages/RoutingSearchPage/RoutingSearchPage.jsx
@@ -51,6 +51,11 @@ export default function RoutingSearchPage() {
   const handleBottomNavChange = (key) => {
     if (key === 'map') {
       navigate(ROUTES.MAP)
+      return
+    }
+
+    if (key === 'my') {
+      navigate('/my')
     }
   }
 

--- a/src/utils/navigation/bottomNavRoute.js
+++ b/src/utils/navigation/bottomNavRoute.js
@@ -1,0 +1,9 @@
+const bottomNavRouteMap = {
+  map: '/map',
+  navigation: '/RoutingSearchPage',
+  my: '/my',
+}
+
+export default function getBottomNavRoute(key) {
+  return bottomNavRouteMap[key] ?? '/map'
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closed #34 

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
Mypage UI 구현 완료 했습니다. 
추가로 로그인했을 때 프로필정보 api 연동도 완료했습니다.

리뷰나 로그아웃 비밀번호 변경은 중요도가 낮다고 생각해 패스했습니다.
그래도 하단바에 마이페이지가 있으니까 ui 정도는 구현해야한다고 생각했어요.
해당 부분 데이터는 그냥 하드 코딩 했습니다. 리뷰나 저장된 거 같은 경우는요~

### 스크린샷 (선택)
https://github.com/user-attachments/assets/ce634b40-1461-4eeb-8f0e-9d1e2cbf623d


<img width="407" height="757" alt="스크린샷 2026-05-31 오후 10 04 21" src="https://github.com/user-attachments/assets/0fe59880-3dcc-4e31-8e51-0b428eee45cc" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 마이페이지 및 계정 관리 기능 추가

* **New Features**
  * 마이페이지 추가: 프로필 조회/수정, 로그아웃 지원
  * 즐겨찾기 목록 페이지 및 내가 쓴 리뷰 페이지 추가(리스트 조회·삭제)
  * 설정 페이지 추가: 비밀번호 변경·회원 탈퇴(확인 모달) 지원
  * 하단 내비게이션 라우팅 개선으로 마이페이지 접근성 향상

* **Style**
  * 각 마이페이지 관련 화면의 레이아웃 및 컴포넌트 스타일 추가/정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->