### PR TITLE
[feat] 맵-길찾기 출발/도착 상태 연동 및 RoutingSearchPage UX 개선 (#35)

### DIFF
--- a/src/hooks/map/useMapPoiSelection.js
+++ b/src/hooks/map/useMapPoiSelection.js
@@ -1,0 +1,104 @@
+import { useEffect, useRef, useState } from 'react'
+import { getNearestPlace } from '../../apis/placeApi'
+import { isValidMapCenter } from '../../utils/map/mapViewport'
+import { mapNearestPlaceToPoi } from '../../utils/map/mapPoiMappers'
+
+const NEAREST_RADIUS_METERS = 30
+const NOTICE_TIMEOUT_MS = 2400
+const NO_PLACE_CODE = 'PLACE_INFO_NOT_AVAILABLE'
+
+export default function useMapPoiSelection({ initialSelectedPoi, setMapCenter }) {
+  const [mapNotice, setMapNotice] = useState('')
+  const [selectedPoi, setSelectedPoi] = useState(initialSelectedPoi)
+  const [selectedMarkerPosition, setSelectedMarkerPosition] = useState(() =>
+    isValidMapCenter({
+      lat: initialSelectedPoi?.lat,
+      lng: initialSelectedPoi?.lng,
+    })
+      ? { lat: initialSelectedPoi.lat, lng: initialSelectedPoi.lng }
+      : null,
+  )
+  const requestSeqRef = useRef(0)
+  const noticeTimerRef = useRef(null)
+
+  useEffect(() => {
+    return () => {
+      if (noticeTimerRef.current) {
+        window.clearTimeout(noticeTimerRef.current)
+      }
+    }
+  }, [])
+
+  const showMapNotice = (message) => {
+    setMapNotice(message)
+
+    if (noticeTimerRef.current) {
+      window.clearTimeout(noticeTimerRef.current)
+    }
+
+    noticeTimerRef.current = window.setTimeout(() => {
+      setMapNotice('')
+    }, NOTICE_TIMEOUT_MS)
+  }
+
+  const closePoiSheet = () => {
+    setSelectedPoi(null)
+    setSelectedMarkerPosition(null)
+  }
+
+  const handleCurrentLocationSelect = ({ lat, lng }) => {
+    setMapCenter({ lat, lng })
+    setSelectedPoi(null)
+    setSelectedMarkerPosition({ lat, lng })
+    setMapNotice('')
+  }
+
+  const handleMapClick = async ({ lat, lng }) => {
+    const requestId = ++requestSeqRef.current
+
+    try {
+      const { place, code } = await getNearestPlace({
+        lat,
+        lng,
+        radius: NEAREST_RADIUS_METERS,
+      })
+
+      if (requestId !== requestSeqRef.current) return
+
+      if (!place) {
+        setSelectedPoi(null)
+        setSelectedMarkerPosition(null)
+        if (code === NO_PLACE_CODE || code === 'PLACE200_1') {
+          showMapNotice('해당 위치의 장소 정보를 찾을 수 없어요.')
+        }
+        return
+      }
+
+      const mappedPoi = mapNearestPlaceToPoi(place)
+      setMapNotice('')
+      setSelectedPoi(mappedPoi)
+      setMapCenter({
+        lat: mappedPoi.lat,
+        lng: mappedPoi.lng,
+      })
+      setSelectedMarkerPosition({
+        lat: mappedPoi.lat,
+        lng: mappedPoi.lng,
+      })
+    } catch (error) {
+      if (requestId !== requestSeqRef.current) return
+      setSelectedPoi(null)
+      setSelectedMarkerPosition(null)
+      showMapNotice(error?.message ?? '장소 정보를 불러오지 못했습니다.')
+    }
+  }
+
+  return {
+    mapNotice,
+    selectedPoi,
+    selectedMarkerPosition,
+    closePoiSheet,
+    handleCurrentLocationSelect,
+    handleMapClick,
+  }
+}

--- a/src/hooks/map/useMapRoutingBridge.js
+++ b/src/hooks/map/useMapRoutingBridge.js
@@ -1,0 +1,148 @@
+import { getNearestPlace } from '../../apis/placeApi'
+import { ROUTES } from '../../constants/routes'
+import { DEFAULT_ROUTE_ORIGIN } from '../../utils/map/navigationPlaceMapper'
+import {
+  createCurrentLocationOrigin,
+  mapPoiToRoutingPlace,
+} from '../../utils/map/mapPoiMappers'
+
+const NEAREST_RADIUS_METERS = 30
+
+function getCurrentPositionAsync() {
+  return new Promise((resolve, reject) => {
+    if (!navigator.geolocation) {
+      reject(new Error('geolocation-unavailable'))
+      return
+    }
+
+    navigator.geolocation.getCurrentPosition(
+      ({ coords }) => {
+        resolve({
+          lat: coords.latitude,
+          lng: coords.longitude,
+        })
+      },
+      reject,
+      {
+        enableHighAccuracy: true,
+        timeout: 10000,
+        maximumAge: 60000,
+      },
+    )
+  })
+}
+
+export default function useMapRoutingBridge({
+  navigate,
+  routeOrigin,
+  routeDestination,
+  mapCenter,
+  mapLevel,
+  setCurrentNav,
+}) {
+  const openSearchPage = () => {
+    navigate(ROUTES.SEARCH)
+  }
+
+  const handleSearchInputKeyDown = (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      openSearchPage()
+    }
+  }
+
+  const handleBottomNavChange = (key) => {
+    if (key === 'navigation') {
+      navigate(ROUTES.ROUTING_SEARCH, {
+        state: {
+          routeOrigin,
+          routeDestination,
+          mapCenter,
+          mapLevel,
+        },
+      })
+      return
+    }
+
+    setCurrentNav(key)
+  }
+
+  const openRoutingFromMapPoi = async (field, place) => {
+    if (!place) return
+
+    const normalizedPlace = mapPoiToRoutingPlace(place)
+    const nextState =
+      field === 'origin'
+        ? {
+            routeOrigin: normalizedPlace,
+            routeDestination: routeDestination ?? null,
+            selectedRouteField: 'destination',
+          }
+        : {
+            routeOrigin:
+              !routeOrigin || routeOrigin?.source === 'current-location'
+                ? null
+                : routeOrigin,
+            routeDestination: normalizedPlace,
+            selectedRouteField: 'origin',
+          }
+
+    if (field === 'destination' && !nextState.routeOrigin) {
+      let originLat = mapCenter?.lat
+      let originLng = mapCenter?.lng
+
+      try {
+        const currentPosition = await getCurrentPositionAsync()
+        originLat = currentPosition.lat
+        originLng = currentPosition.lng
+      } catch {
+        // 현재 위치 권한 실패 시 지도 중심 좌표를 fallback으로 사용합니다.
+      }
+
+      if (typeof originLat === 'number' && typeof originLng === 'number') {
+        try {
+          const { place: nearestPlace } = await getNearestPlace({
+            lat: originLat,
+            lng: originLng,
+            radius: NEAREST_RADIUS_METERS,
+          })
+          const currentAddress =
+            nearestPlace?.roadAddress ||
+            nearestPlace?.address ||
+            nearestPlace?.name ||
+            '현재 위치'
+
+          nextState.routeOrigin = createCurrentLocationOrigin({
+            lat: originLat,
+            lng: originLng,
+            address: currentAddress,
+          })
+        } catch {
+          nextState.routeOrigin = createCurrentLocationOrigin({
+            lat: originLat,
+            lng: originLng,
+            address: '현재 위치',
+          })
+        }
+      } else {
+        nextState.routeOrigin = DEFAULT_ROUTE_ORIGIN
+      }
+    }
+
+    navigate(ROUTES.ROUTING_SEARCH, {
+      state: {
+        ...nextState,
+        selectedMapPlace: normalizedPlace,
+        mapCenter,
+        mapLevel,
+      },
+    })
+  }
+
+  return {
+    openSearchPage,
+    handleSearchInputKeyDown,
+    handleBottomNavChange,
+    openRoutingFromMapPoi,
+  }
+}

--- a/src/hooks/map/useMapRoutingBridge.js
+++ b/src/hooks/map/useMapRoutingBridge.js
@@ -41,7 +41,14 @@ export default function useMapRoutingBridge({
   setCurrentNav,
 }) {
   const openSearchPage = () => {
-    navigate(ROUTES.SEARCH)
+    navigate(ROUTES.SEARCH, {
+      state: {
+        routeOrigin,
+        routeDestination,
+        mapCenter,
+        mapLevel,
+      },
+    })
   }
 
   const handleSearchInputKeyDown = (event) => {

--- a/src/pages/MapPage/MapPage.jsx
+++ b/src/pages/MapPage/MapPage.jsx
@@ -17,6 +17,7 @@ import './MapPage.css'
 const NEAREST_RADIUS_METERS = 30
 const NOTICE_TIMEOUT_MS = 2400
 const NO_PLACE_CODE = 'PLACE_INFO_NOT_AVAILABLE'
+
 function mapNearestPlaceToPoi(place) {
   return {
     id:
@@ -30,6 +31,30 @@ function mapNearestPlaceToPoi(place) {
     isRegistered: Boolean(place.isRegistered),
     externalApiId: place.externalApiId,
   }
+}
+
+function getCurrentPositionAsync() {
+  return new Promise((resolve, reject) => {
+    if (!navigator.geolocation) {
+      reject(new Error('geolocation-unavailable'))
+      return
+    }
+
+    navigator.geolocation.getCurrentPosition(
+      ({ coords }) => {
+        resolve({
+          lat: coords.latitude,
+          lng: coords.longitude,
+        })
+      },
+      reject,
+      {
+        enableHighAccuracy: true,
+        timeout: 10000,
+        maximumAge: 60000,
+      },
+    )
+  })
 }
 
 function mapRoutePlaceToPoi(place) {
@@ -178,7 +203,7 @@ export default function MapPage() {
     setCurrentNav(key)
   }
 
-  const openRoutingFromMapPoi = (field, place) => {
+  const openRoutingFromMapPoi = async (field, place) => {
     if (!place) return
 
     const normalizedPlace = {
@@ -200,10 +225,65 @@ export default function MapPage() {
             selectedRouteField: 'destination',
           }
         : {
-            routeOrigin: routeOrigin ?? DEFAULT_ROUTE_ORIGIN,
+            routeOrigin:
+              !routeOrigin || routeOrigin?.source === 'current-location'
+                ? null
+                : routeOrigin,
             routeDestination: normalizedPlace,
             selectedRouteField: 'origin',
           }
+
+    if (field === 'destination' && !nextState.routeOrigin) {
+      let originLat = mapCenter?.lat
+      let originLng = mapCenter?.lng
+
+      try {
+        const currentPosition = await getCurrentPositionAsync()
+        originLat = currentPosition.lat
+        originLng = currentPosition.lng
+      } catch {
+        // 현재 위치 권한 실패 시 지도 중심 좌표를 fallback으로 사용합니다.
+      }
+
+      if (typeof originLat === 'number' && typeof originLng === 'number') {
+        try {
+          const { place: nearestPlace } = await getNearestPlace({
+            lat: originLat,
+            lng: originLng,
+            radius: NEAREST_RADIUS_METERS,
+          })
+          const currentAddress =
+            nearestPlace?.roadAddress ||
+            nearestPlace?.address ||
+            nearestPlace?.name ||
+            '현재 위치'
+
+          nextState.routeOrigin = {
+            x: originLng,
+            y: originLat,
+            lat: originLat,
+            lng: originLng,
+            name: currentAddress,
+            title: currentAddress,
+            address: currentAddress,
+            source: 'map-current-location',
+          }
+        } catch {
+          nextState.routeOrigin = {
+            x: originLng,
+            y: originLat,
+            lat: originLat,
+            lng: originLng,
+            name: '현재 위치',
+            title: '현재 위치',
+            address: '현재 위치',
+            source: 'map-current-location',
+          }
+        }
+      } else {
+        nextState.routeOrigin = DEFAULT_ROUTE_ORIGIN
+      }
+    }
 
     navigate(ROUTES.ROUTING_SEARCH, {
       state: {

--- a/src/pages/MapPage/MapPage.jsx
+++ b/src/pages/MapPage/MapPage.jsx
@@ -1,75 +1,19 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
-import { getNearestPlace } from '../../apis/placeApi'
 import BottomNav from '../../components/BottomNav/BottomNav'
 import KakaoMapView from '../../components/Map/KakaoMapView'
 import MapPoiSheet from '../../components/Map/MapPoiSheet'
 import SearchInput from '../../components/SearchInput/SearchInput'
+import useMapPoiSelection from '../../hooks/map/useMapPoiSelection'
+import useMapRoutingBridge from '../../hooks/map/useMapRoutingBridge'
 import { ROUTES } from '../../constants/routes'
 import { mockMapPois } from '../../mocks/map/poi.mock'
 import { mockSearchPlaces } from '../../mocks/search/searchPage.mock'
 import isRegisteredPlace from '../../utils/map/isRegisteredPlace'
 import { getMapViewportState, isValidMapCenter, isValidMapLevel } from '../../utils/map/mapViewport'
-import { DEFAULT_ROUTE_ORIGIN } from '../../utils/map/navigationPlaceMapper'
+import { mapRoutePlaceToPoi } from '../../utils/map/mapPoiMappers'
 import { resolvePoiFromSearch } from '../../utils/map/searchPoiResolver'
 import './MapPage.css'
-
-const NEAREST_RADIUS_METERS = 30
-const NOTICE_TIMEOUT_MS = 2400
-const NO_PLACE_CODE = 'PLACE_INFO_NOT_AVAILABLE'
-
-function mapNearestPlaceToPoi(place) {
-  return {
-    id:
-      place.externalApiId ??
-      place.id ??
-      `${place.name ?? place.placeName ?? 'place'}-${place.lat}-${place.lng}`,
-    name: place.name ?? place.placeName ?? place.title ?? '장소명',
-    address: place.roadAddress || place.address || '주소 정보 없음',
-    lat: place.lat,
-    lng: place.lng,
-    isRegistered: Boolean(place.isRegistered),
-    externalApiId: place.externalApiId,
-  }
-}
-
-function getCurrentPositionAsync() {
-  return new Promise((resolve, reject) => {
-    if (!navigator.geolocation) {
-      reject(new Error('geolocation-unavailable'))
-      return
-    }
-
-    navigator.geolocation.getCurrentPosition(
-      ({ coords }) => {
-        resolve({
-          lat: coords.latitude,
-          lng: coords.longitude,
-        })
-      },
-      reject,
-      {
-        enableHighAccuracy: true,
-        timeout: 10000,
-        maximumAge: 60000,
-      },
-    )
-  })
-}
-
-function mapRoutePlaceToPoi(place) {
-  if (!place) return null
-
-  return {
-    id: place.externalApiId ?? place.id ?? `route-${place.name ?? place.title ?? 'place'}`,
-    name: place.name ?? place.title ?? '장소명',
-    address: place.address ?? place.roadAddress ?? '주소 정보 없음',
-    lat: place.lat,
-    lng: place.lng,
-    isRegistered: Boolean(place.isRegistered),
-    externalApiId: place.externalApiId ?? null,
-  }
-}
 
 export default function MapPage() {
   const location = useLocation()
@@ -100,18 +44,30 @@ export default function MapPage() {
       : mapViewportState.mapCenter
   const [mapCenter, setMapCenter] = useState(initialMapCenter)
   const [mapLevel, setMapLevel] = useState(mapViewportState.mapLevel)
-  const [mapNotice, setMapNotice] = useState('')
-  const [selectedMarkerPosition, setSelectedMarkerPosition] = useState(() =>
-    isValidMapCenter({
-      lat: initialSelectedPoi?.lat,
-      lng: initialSelectedPoi?.lng,
-    })
-      ? { lat: initialSelectedPoi.lat, lng: initialSelectedPoi.lng }
-      : null,
-  )
-  const [selectedPoi, setSelectedPoi] = useState(initialSelectedPoi)
-  const requestSeqRef = useRef(0)
-  const noticeTimerRef = useRef(null)
+  const {
+    mapNotice,
+    selectedPoi,
+    selectedMarkerPosition,
+    closePoiSheet,
+    handleCurrentLocationSelect,
+    handleMapClick,
+  } = useMapPoiSelection({
+    initialSelectedPoi,
+    setMapCenter,
+  })
+  const {
+    openSearchPage,
+    handleSearchInputKeyDown,
+    handleBottomNavChange,
+    openRoutingFromMapPoi,
+  } = useMapRoutingBridge({
+    navigate,
+    routeOrigin,
+    routeDestination,
+    mapCenter,
+    mapLevel,
+    setCurrentNav,
+  })
   const registeredPlaces = useMemo(
     () => mockSearchPlaces.filter((place) => place.isRegistered),
     [],
@@ -123,14 +79,6 @@ export default function MapPage() {
         : isRegisteredPlace(selectedPoi, registeredPlaces),
     [registeredPlaces, selectedPoi],
   )
-
-  useEffect(() => {
-    return () => {
-      if (noticeTimerRef.current) {
-        window.clearTimeout(noticeTimerRef.current)
-      }
-    }
-  }, [])
 
   useEffect(() => {
     if (shouldOpenFromSearch || hasInitialViewportFromState) return
@@ -158,189 +106,6 @@ export default function MapPage() {
     if (!selectedSearchPlace && !selectedMapPlace) return
     navigate(ROUTES.MAP, { replace: true, state: null })
   }, [navigate, selectedMapPlace, selectedSearchPlace])
-
-  const showMapNotice = (message) => {
-    setMapNotice(message)
-
-    if (noticeTimerRef.current) {
-      window.clearTimeout(noticeTimerRef.current)
-    }
-
-    noticeTimerRef.current = window.setTimeout(() => {
-      setMapNotice('')
-    }, NOTICE_TIMEOUT_MS)
-  }
-
-  const closePoiSheet = () => {
-    setSelectedPoi(null)
-    setSelectedMarkerPosition(null)
-  }
-
-  const openSearchPage = () => {
-    navigate(ROUTES.SEARCH)
-  }
-
-  const handleSearchInputKeyDown = (event) => {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault()
-      openSearchPage()
-    }
-  }
-
-  const handleBottomNavChange = (key) => {
-    if (key === 'navigation') {
-      navigate(ROUTES.ROUTING_SEARCH, {
-        state: {
-          routeOrigin,
-          routeDestination,
-          mapCenter,
-          mapLevel,
-        },
-      })
-      return
-    }
-
-    setCurrentNav(key)
-  }
-
-  const openRoutingFromMapPoi = async (field, place) => {
-    if (!place) return
-
-    const normalizedPlace = {
-      ...place,
-      name: place.name ?? place.title ?? '장소',
-      title: place.name ?? place.title ?? '장소',
-      address: place.address ?? '주소 정보 없음',
-      lat: place.lat,
-      lng: place.lng,
-      externalApiId: place.externalApiId ?? place.id ?? null,
-      isRegistered: Boolean(place.isRegistered),
-    }
-
-    const nextState =
-      field === 'origin'
-        ? {
-            routeOrigin: normalizedPlace,
-            routeDestination: routeDestination ?? null,
-            selectedRouteField: 'destination',
-          }
-        : {
-            routeOrigin:
-              !routeOrigin || routeOrigin?.source === 'current-location'
-                ? null
-                : routeOrigin,
-            routeDestination: normalizedPlace,
-            selectedRouteField: 'origin',
-          }
-
-    if (field === 'destination' && !nextState.routeOrigin) {
-      let originLat = mapCenter?.lat
-      let originLng = mapCenter?.lng
-
-      try {
-        const currentPosition = await getCurrentPositionAsync()
-        originLat = currentPosition.lat
-        originLng = currentPosition.lng
-      } catch {
-        // 현재 위치 권한 실패 시 지도 중심 좌표를 fallback으로 사용합니다.
-      }
-
-      if (typeof originLat === 'number' && typeof originLng === 'number') {
-        try {
-          const { place: nearestPlace } = await getNearestPlace({
-            lat: originLat,
-            lng: originLng,
-            radius: NEAREST_RADIUS_METERS,
-          })
-          const currentAddress =
-            nearestPlace?.roadAddress ||
-            nearestPlace?.address ||
-            nearestPlace?.name ||
-            '현재 위치'
-
-          nextState.routeOrigin = {
-            x: originLng,
-            y: originLat,
-            lat: originLat,
-            lng: originLng,
-            name: currentAddress,
-            title: currentAddress,
-            address: currentAddress,
-            source: 'map-current-location',
-          }
-        } catch {
-          nextState.routeOrigin = {
-            x: originLng,
-            y: originLat,
-            lat: originLat,
-            lng: originLng,
-            name: '현재 위치',
-            title: '현재 위치',
-            address: '현재 위치',
-            source: 'map-current-location',
-          }
-        }
-      } else {
-        nextState.routeOrigin = DEFAULT_ROUTE_ORIGIN
-      }
-    }
-
-    navigate(ROUTES.ROUTING_SEARCH, {
-      state: {
-        ...nextState,
-        selectedMapPlace: normalizedPlace,
-        mapCenter,
-        mapLevel,
-      },
-    })
-  }
-
-  const handleCurrentLocationSelect = ({ lat, lng }) => {
-    setMapCenter({ lat, lng })
-    setSelectedPoi(null)
-    setSelectedMarkerPosition({ lat, lng })
-    setMapNotice('')
-  }
-
-  const handleMapClick = async ({ lat, lng }) => {
-    const requestId = ++requestSeqRef.current
-
-    try {
-      const { place, code } = await getNearestPlace({
-        lat,
-        lng,
-        radius: NEAREST_RADIUS_METERS,
-      })
-
-      if (requestId !== requestSeqRef.current) return
-
-      if (!place) {
-        setSelectedPoi(null)
-        setSelectedMarkerPosition(null)
-        if (code === NO_PLACE_CODE || code === 'PLACE200_1') {
-          showMapNotice('해당 위치의 장소 정보를 찾을 수 없어요.')
-        }
-        return
-      }
-
-      const mappedPoi = mapNearestPlaceToPoi(place)
-      setMapNotice('')
-      setSelectedPoi(mappedPoi)
-      setMapCenter({
-        lat: mappedPoi.lat,
-        lng: mappedPoi.lng,
-      })
-      setSelectedMarkerPosition({
-        lat: mappedPoi.lat,
-        lng: mappedPoi.lng,
-      })
-    } catch (error) {
-      if (requestId !== requestSeqRef.current) return
-      setSelectedPoi(null)
-      setSelectedMarkerPosition(null)
-      showMapNotice(error?.message ?? '장소 정보를 불러오지 못했습니다.')
-    }
-  }
 
   return (
     <main className="map-page">

--- a/src/pages/MapPage/MapPage.jsx
+++ b/src/pages/MapPage/MapPage.jsx
@@ -5,12 +5,12 @@ import BottomNav from '../../components/BottomNav/BottomNav'
 import KakaoMapView from '../../components/Map/KakaoMapView'
 import MapPoiSheet from '../../components/Map/MapPoiSheet'
 import SearchInput from '../../components/SearchInput/SearchInput'
-import { DEFAULT_MAP_CENTER, DEFAULT_MAP_LEVEL } from '../../constants/map'
 import { ROUTES } from '../../constants/routes'
 import { mockMapPois } from '../../mocks/map/poi.mock'
 import { mockSearchPlaces } from '../../mocks/search/searchPage.mock'
 import isRegisteredPlace from '../../utils/map/isRegisteredPlace'
-import { isValidMapCenter } from '../../utils/map/mapViewport'
+import { getMapViewportState, isValidMapCenter, isValidMapLevel } from '../../utils/map/mapViewport'
+import { DEFAULT_ROUTE_ORIGIN } from '../../utils/map/navigationPlaceMapper'
 import { resolvePoiFromSearch } from '../../utils/map/searchPoiResolver'
 import './MapPage.css'
 
@@ -32,14 +32,38 @@ function mapNearestPlaceToPoi(place) {
   }
 }
 
+function mapRoutePlaceToPoi(place) {
+  if (!place) return null
+
+  return {
+    id: place.externalApiId ?? place.id ?? `route-${place.name ?? place.title ?? 'place'}`,
+    name: place.name ?? place.title ?? '장소명',
+    address: place.address ?? place.roadAddress ?? '주소 정보 없음',
+    lat: place.lat,
+    lng: place.lng,
+    isRegistered: Boolean(place.isRegistered),
+    externalApiId: place.externalApiId ?? null,
+  }
+}
+
 export default function MapPage() {
   const location = useLocation()
   const navigate = useNavigate()
+  const routeState = location.state
+  const mapViewportState = getMapViewportState(routeState)
+  const routeOrigin = location.state?.routeOrigin ?? null
+  const routeDestination = location.state?.routeDestination ?? null
   const selectedSearchPlace = location.state?.selectedSearchPlace
+  const selectedMapPlace = location.state?.selectedMapPlace
   const shouldOpenFromSearch = location.state?.openSheetFrom === 'search-result'
+  const shouldOpenFromRouting = location.state?.openSheetFrom === 'routing-return'
+  const hasInitialViewportFromState =
+    isValidMapCenter(routeState?.mapCenter) || isValidMapLevel(routeState?.mapLevel)
   const initialSelectedPoi =
     shouldOpenFromSearch && selectedSearchPlace
       ? resolvePoiFromSearch(selectedSearchPlace, mockMapPois)
+      : shouldOpenFromRouting && selectedMapPlace
+        ? mapRoutePlaceToPoi(selectedMapPlace)
       : null
   const [currentNav, setCurrentNav] = useState('map')
   const initialMapCenter =
@@ -48,9 +72,9 @@ export default function MapPage() {
       lng: initialSelectedPoi?.lng,
     })
       ? { lat: initialSelectedPoi.lat, lng: initialSelectedPoi.lng }
-      : DEFAULT_MAP_CENTER
+      : mapViewportState.mapCenter
   const [mapCenter, setMapCenter] = useState(initialMapCenter)
-  const [mapLevel, setMapLevel] = useState(DEFAULT_MAP_LEVEL)
+  const [mapLevel, setMapLevel] = useState(mapViewportState.mapLevel)
   const [mapNotice, setMapNotice] = useState('')
   const [selectedMarkerPosition, setSelectedMarkerPosition] = useState(() =>
     isValidMapCenter({
@@ -84,7 +108,7 @@ export default function MapPage() {
   }, [])
 
   useEffect(() => {
-    if (shouldOpenFromSearch) return
+    if (shouldOpenFromSearch || hasInitialViewportFromState) return
     if (!navigator.geolocation) return
 
     navigator.geolocation.getCurrentPosition(
@@ -103,12 +127,12 @@ export default function MapPage() {
         maximumAge: 60000,
       },
     )
-  }, [setMapCenter, shouldOpenFromSearch])
+  }, [hasInitialViewportFromState, setMapCenter, shouldOpenFromSearch])
 
   useEffect(() => {
-    if (!selectedSearchPlace) return
+    if (!selectedSearchPlace && !selectedMapPlace) return
     navigate(ROUTES.MAP, { replace: true, state: null })
-  }, [navigate, selectedSearchPlace])
+  }, [navigate, selectedMapPlace, selectedSearchPlace])
 
   const showMapNotice = (message) => {
     setMapNotice(message)
@@ -142,6 +166,8 @@ export default function MapPage() {
     if (key === 'navigation') {
       navigate(ROUTES.ROUTING_SEARCH, {
         state: {
+          routeOrigin,
+          routeDestination,
           mapCenter,
           mapLevel,
         },
@@ -150,6 +176,43 @@ export default function MapPage() {
     }
 
     setCurrentNav(key)
+  }
+
+  const openRoutingFromMapPoi = (field, place) => {
+    if (!place) return
+
+    const normalizedPlace = {
+      ...place,
+      name: place.name ?? place.title ?? '장소',
+      title: place.name ?? place.title ?? '장소',
+      address: place.address ?? '주소 정보 없음',
+      lat: place.lat,
+      lng: place.lng,
+      externalApiId: place.externalApiId ?? place.id ?? null,
+      isRegistered: Boolean(place.isRegistered),
+    }
+
+    const nextState =
+      field === 'origin'
+        ? {
+            routeOrigin: normalizedPlace,
+            routeDestination: routeDestination ?? null,
+            selectedRouteField: 'destination',
+          }
+        : {
+            routeOrigin: routeOrigin ?? DEFAULT_ROUTE_ORIGIN,
+            routeDestination: normalizedPlace,
+            selectedRouteField: 'origin',
+          }
+
+    navigate(ROUTES.ROUTING_SEARCH, {
+      state: {
+        ...nextState,
+        selectedMapPlace: normalizedPlace,
+        mapCenter,
+        mapLevel,
+      },
+    })
   }
 
   const handleCurrentLocationSelect = ({ lat, lng }) => {
@@ -234,6 +297,8 @@ export default function MapPage() {
         place={selectedPoi}
         isRegistered={isSelectedPoiRegistered}
         onClose={closePoiSheet}
+        onDeparture={(place) => openRoutingFromMapPoi('origin', place)}
+        onArrival={(place) => openRoutingFromMapPoi('destination', place)}
       />
     </main>
   )

--- a/src/pages/MapPage/MapPage.jsx
+++ b/src/pages/MapPage/MapPage.jsx
@@ -104,8 +104,24 @@ export default function MapPage() {
 
   useEffect(() => {
     if (!selectedSearchPlace && !selectedMapPlace) return
-    navigate(ROUTES.MAP, { replace: true, state: null })
-  }, [navigate, selectedMapPlace, selectedSearchPlace])
+    navigate(ROUTES.MAP, {
+      replace: true,
+      state: {
+        routeOrigin: routeOrigin ?? null,
+        routeDestination: routeDestination ?? null,
+        mapCenter,
+        mapLevel,
+      },
+    })
+  }, [
+    mapCenter,
+    mapLevel,
+    navigate,
+    routeDestination,
+    routeOrigin,
+    selectedMapPlace,
+    selectedSearchPlace,
+  ])
 
   return (
     <main className="map-page">

--- a/src/pages/RoutingSearchPage/RoutingSearchPage.jsx
+++ b/src/pages/RoutingSearchPage/RoutingSearchPage.jsx
@@ -15,8 +15,11 @@ function getPlaceName(place, fallback) {
 export default function RoutingSearchPage() {
   const location = useLocation()
   const navigate = useNavigate()
-  const routeOrigin = location.state?.routeOrigin ?? DEFAULT_ROUTE_ORIGIN
-  const routeDestination = location.state?.routeDestination ?? null
+  const routeOriginState = location.state?.routeOrigin ?? null
+  const routeDestinationState = location.state?.routeDestination ?? null
+  const selectedMapPlace = location.state?.selectedMapPlace ?? null
+  const routeOrigin = routeOriginState ?? DEFAULT_ROUTE_ORIGIN
+  const routeDestination = routeDestinationState ?? null
   const initialMapViewport = getMapViewportState(location.state)
   const [mapCenter, setMapCenter] = useState(initialMapViewport.mapCenter)
   const [mapLevel, setMapLevel] = useState(initialMapViewport.mapLevel)
@@ -42,6 +45,7 @@ export default function RoutingSearchPage() {
         returnTo: ROUTES.ROUTING_SEARCH,
         routeOrigin,
         routeDestination,
+        selectedMapPlace,
         mapCenter,
         mapLevel,
       },
@@ -50,7 +54,14 @@ export default function RoutingSearchPage() {
 
   const handleBottomNavChange = (key) => {
     if (key === 'map') {
-      navigate(ROUTES.MAP)
+      navigate(ROUTES.MAP, {
+        state: {
+          routeOrigin,
+          routeDestination,
+          mapCenter,
+          mapLevel,
+        },
+      })
     }
   }
 

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -30,6 +30,7 @@ export default function SearchPage() {
   const returnTo = location.state?.returnTo ?? ROUTES.ROUTING_SEARCH
   const routeOrigin = location.state?.routeOrigin ?? null
   const routeDestination = location.state?.routeDestination ?? null
+  const selectedMapPlace = location.state?.selectedMapPlace ?? null
   const mapCenter = location.state?.mapCenter ?? null
   const mapLevel = location.state?.mapLevel ?? null
   const supportsGeolocation =
@@ -243,10 +244,10 @@ export default function SearchPage() {
         state: {
           routeOrigin: nextOrigin,
           routeDestination: nextDestination,
+          selectedMapPlace,
           mapCenter,
           mapLevel,
           selectedRouteField: routeField,
-          isRouteReady: Boolean(nextOrigin && nextDestination),
         },
       })
       return

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -12,14 +12,42 @@ const SEARCH_DELAY_MS = 250
 const SUGGEST_DELAY_MS = 180
 const SEARCH_SIZE = 15
 const SUGGEST_SIZE = 10
+const GEOLOCATION_INITIAL_OPTIONS = {
+  enableHighAccuracy: true,
+  timeout: 10000,
+  maximumAge: 60000,
+}
+const GEOLOCATION_WATCH_OPTIONS = {
+  enableHighAccuracy: true,
+  timeout: 10000,
+  maximumAge: 0,
+}
 const normalizeText = (value = '') => value.trim().toLowerCase()
 const HANGUL_JAMO_ONLY_REGEX = /^[ㄱ-ㅎㅏ-ㅣ]+$/
 const GEOLOCATION_UNAVAILABLE_MESSAGE = '현재 위치 정보를 사용할 수 없습니다.'
 const GEOLOCATION_REQUIRED_MESSAGE = '현재 위치를 확인한 뒤 다시 검색해 주세요.'
 const SEARCH_FAILED_MESSAGE = '검색 결과를 불러오지 못했습니다.'
+const DEBUG_SUGGEST_LOG = import.meta.env.DEV && import.meta.env.VITE_DEBUG_SUGGEST_LOG === 'true'
 
 function isInvalidIntermediateKeyword(keyword) {
   return HANGUL_JAMO_ONLY_REGEX.test(keyword)
+}
+
+function getNowMs() {
+  return typeof performance !== 'undefined' ? performance.now() : Date.now()
+}
+
+function mapPlaceToSearchItem(place, idx) {
+  return {
+    id: place.externalApiId ?? `${place.name}-${idx}`,
+    title: place.name,
+    address: place.roadAddress || place.address || '주소 정보 없음',
+    isRegistered: Boolean(place.isRegistered),
+    lat: place.lat,
+    lng: place.lng,
+    externalApiId: place.externalApiId,
+    distanceMeters: place.distanceMeters ?? null,
+  }
 }
 
 export default function SearchPage() {
@@ -49,57 +77,76 @@ export default function SearchPage() {
   const suggestTimerRef = useRef(null)
   const requestSeqRef = useRef(0)
   const suggestSeqRef = useRef(0)
+  const mountedAtRef = useRef(getNowMs())
+  const lastLocationUpdatedAtRef = useRef(null)
+
+  const getCenterParams = () => ({
+    lat: searchCenter?.lat,
+    lng: searchCenter?.lng,
+  })
+
+  const clearTimer = (timerRef) => {
+    if (!timerRef.current) return
+    window.clearTimeout(timerRef.current)
+    timerRef.current = null
+  }
 
   const invalidatePendingSearch = () => {
     requestSeqRef.current += 1
-    if (searchTimerRef.current) {
-      window.clearTimeout(searchTimerRef.current)
-      searchTimerRef.current = null
-    }
+    clearTimer(searchTimerRef)
   }
 
   const invalidatePendingSuggest = () => {
     suggestSeqRef.current += 1
-    if (suggestTimerRef.current) {
-      window.clearTimeout(suggestTimerRef.current)
-      suggestTimerRef.current = null
-    }
+    clearTimer(suggestTimerRef)
   }
 
   useEffect(() => {
     return () => {
       requestSeqRef.current += 1
-      if (searchTimerRef.current) {
-        window.clearTimeout(searchTimerRef.current)
-        searchTimerRef.current = null
-      }
+      clearTimer(searchTimerRef)
       suggestSeqRef.current += 1
-      if (suggestTimerRef.current) {
-        window.clearTimeout(suggestTimerRef.current)
-        suggestTimerRef.current = null
-      }
+      clearTimer(suggestTimerRef)
     }
   }, [])
 
   useEffect(() => {
     if (!supportsGeolocation) return
 
-    navigator.geolocation.getCurrentPosition(
-      ({ coords }) => {
-        setSearchCenter({
+    const handleSuccess = ({ coords }) => {
+      const updatedAt = getNowMs()
+      lastLocationUpdatedAtRef.current = updatedAt
+      setSearchCenter({
+        lat: coords.latitude,
+        lng: coords.longitude,
+      })
+
+      if (DEBUG_SUGGEST_LOG) {
+        console.debug('[search][geo:update]', {
+          elapsedMsFromMount: Math.round(updatedAt - mountedAtRef.current),
           lat: coords.latitude,
           lng: coords.longitude,
         })
-      },
-      () => {
-        setSearchStateMessage(GEOLOCATION_REQUIRED_MESSAGE)
-      },
-      {
-        enableHighAccuracy: true,
-        timeout: 10000,
-        maximumAge: 60000,
-      },
+      }
+    }
+
+    const handleError = () => {
+      setSearchStateMessage(GEOLOCATION_REQUIRED_MESSAGE)
+    }
+
+    navigator.geolocation.getCurrentPosition(
+      handleSuccess,
+      handleError,
+      GEOLOCATION_INITIAL_OPTIONS,
     )
+
+    const watchId = navigator.geolocation.watchPosition(handleSuccess, handleError, {
+      ...GEOLOCATION_WATCH_OPTIONS,
+    })
+
+    return () => {
+      navigator.geolocation.clearWatch(watchId)
+    }
   }, [supportsGeolocation])
 
   const suggestByKeyword = (rawKeyword) => {
@@ -111,36 +158,38 @@ export default function SearchPage() {
       return
     }
 
-    if (suggestTimerRef.current) {
-      window.clearTimeout(suggestTimerRef.current)
-      suggestTimerRef.current = null
-    }
+    clearTimer(suggestTimerRef)
 
     const requestId = ++suggestSeqRef.current
 
     suggestTimerRef.current = window.setTimeout(async () => {
       try {
+        const { lat, lng } = getCenterParams()
+
+        if (DEBUG_SUGGEST_LOG) {
+          const now = getNowMs()
+          console.debug('[search][suggest:req]', {
+            q: normalized,
+            lat: lat ?? null,
+            lng: lng ?? null,
+            size: SUGGEST_SIZE,
+            elapsedMsFromMount: Math.round(now - mountedAtRef.current),
+            elapsedMsAfterGeoUpdate: lastLocationUpdatedAtRef.current
+              ? Math.round(now - lastLocationUpdatedAtRef.current)
+              : null,
+          })
+        }
+
         const suggestions = await suggestPlaces({
           keyword: normalized,
-          lat: searchCenter?.lat,
-          lng: searchCenter?.lng,
+          lat,
+          lng,
           size: SUGGEST_SIZE,
         })
 
         if (requestId !== suggestSeqRef.current) return
 
-        const mappedSuggestions = suggestions.map((item, idx) => ({
-          id: item.externalApiId ?? `${item.name}-${idx}`,
-          title: item.name,
-          address: item.roadAddress || item.address || '주소 정보 없음',
-          isRegistered: Boolean(item.isRegistered),
-          lat: item.lat,
-          lng: item.lng,
-          externalApiId: item.externalApiId,
-          distanceMeters: item.distanceMeters ?? null,
-        }))
-
-        setAutocompleteItems(mappedSuggestions)
+        setAutocompleteItems(suggestions.map(mapPlaceToSearchItem))
       } catch {
         if (requestId !== suggestSeqRef.current) return
         setAutocompleteItems([])
@@ -176,35 +225,22 @@ export default function SearchPage() {
     setHasSearchError(false)
     setSearchStateMessage('')
 
-    if (searchTimerRef.current) {
-      window.clearTimeout(searchTimerRef.current)
-      searchTimerRef.current = null
-    }
+    clearTimer(searchTimerRef)
 
     const requestId = ++requestSeqRef.current
 
     searchTimerRef.current = window.setTimeout(async () => {
       try {
+        const { lat, lng } = getCenterParams()
         const places = await searchPlaces({
           keyword: normalized,
-          lat: searchCenter?.lat,
-          lng: searchCenter?.lng,
+          lat,
+          lng,
           size: SEARCH_SIZE,
         })
         if (requestId !== requestSeqRef.current) return
 
-        const mappedPlaces = places.map((place, idx) => ({
-          id: place.externalApiId ?? `${place.name}-${idx}`,
-          title: place.name,
-          address: place.roadAddress || place.address || '주소 정보 없음',
-          isRegistered: Boolean(place.isRegistered),
-          lat: place.lat,
-          lng: place.lng,
-          externalApiId: place.externalApiId,
-          distanceMeters: place.distanceMeters ?? null,
-        }))
-
-        setResultItems(mappedPlaces)
+        setResultItems(places.map(mapPlaceToSearchItem))
       } catch (error) {
         if (requestId !== requestSeqRef.current) return
         setHasSearchError(true)

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -257,6 +257,11 @@ export default function SearchPage() {
       state: {
         selectedSearchPlace: selectedPlace,
         openSheetFrom: 'search-result',
+        routeOrigin,
+        routeDestination,
+        mapCenter,
+        mapLevel,
+        selectedMapPlace,
       },
     })
   }

--- a/src/utils/map/mapPoiMappers.js
+++ b/src/utils/map/mapPoiMappers.js
@@ -53,6 +53,6 @@ export function createCurrentLocationOrigin({ lat, lng, address }) {
     name: safeAddress,
     title: safeAddress,
     address: safeAddress,
-    source: 'map-current-location',
+    source: 'current-location',
   }
 }

--- a/src/utils/map/mapPoiMappers.js
+++ b/src/utils/map/mapPoiMappers.js
@@ -1,0 +1,58 @@
+export function mapNearestPlaceToPoi(place) {
+  return {
+    id:
+      place.externalApiId ??
+      place.id ??
+      `${place.name ?? place.placeName ?? 'place'}-${place.lat}-${place.lng}`,
+    name: place.name ?? place.placeName ?? place.title ?? '장소명',
+    address: place.roadAddress || place.address || '주소 정보 없음',
+    lat: place.lat,
+    lng: place.lng,
+    isRegistered: Boolean(place.isRegistered),
+    externalApiId: place.externalApiId,
+  }
+}
+
+export function mapRoutePlaceToPoi(place) {
+  if (!place) return null
+
+  return {
+    id: place.externalApiId ?? place.id ?? `route-${place.name ?? place.title ?? 'place'}`,
+    name: place.name ?? place.title ?? '장소명',
+    address: place.address ?? place.roadAddress ?? '주소 정보 없음',
+    lat: place.lat,
+    lng: place.lng,
+    isRegistered: Boolean(place.isRegistered),
+    externalApiId: place.externalApiId ?? null,
+  }
+}
+
+export function mapPoiToRoutingPlace(place) {
+  if (!place) return null
+
+  return {
+    ...place,
+    name: place.name ?? place.title ?? '장소',
+    title: place.name ?? place.title ?? '장소',
+    address: place.address ?? '주소 정보 없음',
+    lat: place.lat,
+    lng: place.lng,
+    externalApiId: place.externalApiId ?? place.id ?? null,
+    isRegistered: Boolean(place.isRegistered),
+  }
+}
+
+export function createCurrentLocationOrigin({ lat, lng, address }) {
+  const safeAddress = address || '현재 위치'
+
+  return {
+    x: lng,
+    y: lat,
+    lat,
+    lng,
+    name: safeAddress,
+    title: safeAddress,
+    address: safeAddress,
+    source: 'map-current-location',
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closed #35

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- map ↔ RoutingSearchPage 이동 시 지도 상태를 유지하도록 라우트 state 전달/복원 로직을 추가했어요.
- /map 바텀시트에서 출발/도착 선택 시 RoutingSearchPage의 출발지/도착지 입력값이 바로 반영되도록 연결했어요.
- 특히 /map에서 출발지 없이 도착을 먼저 선택한 경우, 출발지를 현재 위치 기반으로 채우도록 보완했어요.
  - 현재 위치 좌표 획득 후 nearest 조회로 주소를 우선 반영하도록 했어요.
  - 위치 권한 실패/조회 실패 시 안전한 fallback 처리
- RoutingSearchPage에서 map 하단탭 이동 시, 기존 출발/도착 상태가 사라지지 않도록 state 전달했어요.
- `/routing` 자동 진입 흐름은 제외하고, 이번 PR은 `/RoutingSearchPage` 중심 UX에 맞춰 정리했습니다.

### 스크린샷 (선택)

https://github.com/user-attachments/assets/67b96a27-941c-4181-810e-829a00c12d24

https://github.com/user-attachments/assets/2e53527e-b797-4b81-b9bc-f0ed0dbe8640


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 해당 부분 ux 흐름 맞는지 확인 부탁드려요 ~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 지도 POI 선택 동작 개선: 탭/클릭으로 근처 장소를 자동 조회하고 선택 마커와 안내 메시지가 동기화됩니다.
  * 지도에서 바로 출발지/도착지 선택 및 라우팅 전환이 가능해졌습니다.
  * 현재 위치를 기반으로 한 출발지 생성 및 경로 검색 흐름이 추가되었습니다.

* **Refactor**
  * 지도·검색·내비게이션 간 상태 전달과 초기 뷰포인트 처리가 정리되어 일관성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->