### PR TITLE
[fix] add vercel SPA rewrite (#47)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> Related #이슈번호

## 📝작업 내용
- Vercel 배포 환경에서 클라이언트 라우팅 경로가 404로 처리되지 않도록 SPA rewrite 설정을 추가했습니다.
- `/RoutingOptionPage`, `/RoutingSearchPage` 같은 프론트 라우팅 경로가 직접 진입해도 `index.html`을 내려주도록 설정했습니다.

## ✅테스트
- Vercel preview 배포 후 라우팅 경로 직접 진입 확인

## 💬리뷰 요구사항
- Vercel 배포 환경에서 새로고침 및 직접 진입 시 404가 발생하지 않는지 확인 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **Chores**
  * 싱글 페이지 애플리케이션 라우팅 설정이 추가되었습니다. 모든 경로가 기본 HTML 진입점으로 올바르게 매핑되어 배포 환경에서 클라이언트 측 라우팅이 안정적으로 작동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->