### PR TITLE
[fix] POI 선택 해제 시 건물 기준으로 경로 설정(#55)

### DIFF
--- a/src/components/BottomSheet/types/BottomSheetPlaceDetail.jsx
+++ b/src/components/BottomSheet/types/BottomSheetPlaceDetail.jsx
@@ -33,6 +33,7 @@ export default function BottomSheetPlaceDetail({
   showPOIs = false,
   onTogglePOIs,
   selectedPoiId = null,
+  selectedPoiName = null,
   onSelectPoi,
   reviewSummary = { rating: 0, count: 0 },
   reviews = [],
@@ -83,7 +84,9 @@ export default function BottomSheetPlaceDetail({
       />
 
       <StickyActionSection $sticky={false}>
-        <ActionTitle>건물 입구로 가기</ActionTitle>
+        <ActionTitle>
+          {selectedPoiName ? `${selectedPoiName}로 가기` : '건물 입구로 가기'}
+        </ActionTitle>
         <BottomSheetActionBar
           leftLabel="출발"
           rightLabel="도착"

--- a/src/components/Map/MapPoiSheet.jsx
+++ b/src/components/Map/MapPoiSheet.jsx
@@ -26,6 +26,7 @@ export default function MapPoiSheet({
     showPOIs: false,
     selectedFloor: null,
     selectedPoiId: null,
+    hasPoiSelectionOverride: false,
   })
   const [isLoggedIn, setIsLoggedIn] = useState(false)
   const isCurrentPlaceDetail =
@@ -183,7 +184,9 @@ export default function MapPoiSheet({
   }, [place, placeDetail, resolvedIsRegistered, sheetTitle])
 
   const hasPoiPanelState = poiPanelState.key === placeKey
-  const selectedPoiId = hasPoiPanelState
+  const hasPoiSelectionOverride =
+    hasPoiPanelState && poiPanelState.hasPoiSelectionOverride
+  const selectedPoiId = hasPoiSelectionOverride
     ? poiPanelState.selectedPoiId
     : selectedPoiFromPlace?.id ?? null
   const selectedFloor = hasPoiPanelState
@@ -194,20 +197,38 @@ export default function MapPoiSheet({
     : Boolean(selectedPoiFromPlace)
 
   const selectedPoi = useMemo(() => {
+    if (hasPoiSelectionOverride && !selectedPoiId) {
+      return null
+    }
+
     if (!selectedPoiId) return selectedPoiFromPlace
 
     return pois.find((poi) => poi.id === selectedPoiId) ?? selectedPoiFromPlace
-  }, [pois, selectedPoiFromPlace, selectedPoiId])
+  }, [hasPoiSelectionOverride, pois, selectedPoiFromPlace, selectedPoiId])
 
   const routablePlace = useMemo(() => {
     if (!place) return null
 
+    const buildingPlaceId = place.placeId ?? place.destinationBuildingId ?? null
+
     if (!selectedPoi) {
-      return place
+      return {
+        ...place,
+        placeId: buildingPlaceId,
+        poiId: null,
+        publicId: buildingPlaceId,
+        startPoiId: null,
+        destinationPoiId: null,
+        destinationBuildingId: buildingPlaceId,
+        name: building.name ?? sheetTitle,
+        title: building.name ?? sheetTitle,
+        displayName: building.name ?? sheetTitle,
+        parentBuildingName: null,
+        address: building.address ?? place.address ?? '주소 정보 없음',
+      }
     }
 
     const selectedPoiIdentifier = selectedPoi.id ?? selectedPoi.externalApiId ?? null
-    const buildingPlaceId = place.placeId ?? place.destinationBuildingId ?? null
 
     return {
       ...place,
@@ -220,7 +241,7 @@ export default function MapPoiSheet({
       destinationPoiId: selectedPoiIdentifier,
       destinationBuildingId: buildingPlaceId,
     }
-  }, [place, selectedPoi])
+  }, [building.address, building.name, place, selectedPoi, sheetTitle])
 
   const handleClose = () => {
     setPoiPanelState({
@@ -228,6 +249,7 @@ export default function MapPoiSheet({
       showPOIs: false,
       selectedFloor: null,
       selectedPoiId: null,
+      hasPoiSelectionOverride: false,
     })
     onClose?.()
   }
@@ -235,11 +257,22 @@ export default function MapPoiSheet({
   const handleSelectPoi = (poi) => {
     if (!poi) return
 
-    setPoiPanelState({
-      key: placeKey,
-      showPOIs: true,
-      selectedFloor: normalizeFloorNumber(poi.floor),
-      selectedPoiId: poi.id ?? null,
+    setPoiPanelState((currentState) => {
+      const nextPoiId = poi.id ?? null
+      const currentPoiId =
+        currentState.key === placeKey ? currentState.selectedPoiId : null
+      const isSamePoiSelected =
+        currentPoiId != null &&
+        nextPoiId != null &&
+        String(currentPoiId) === String(nextPoiId)
+
+      return {
+        key: placeKey,
+        showPOIs: true,
+        selectedFloor: normalizeFloorNumber(poi.floor),
+        selectedPoiId: isSamePoiSelected ? null : nextPoiId,
+        hasPoiSelectionOverride: true,
+      }
     })
   }
 
@@ -250,6 +283,10 @@ export default function MapPoiSheet({
       selectedFloor: floor,
       selectedPoiId:
         currentState.key === placeKey ? currentState.selectedPoiId : null,
+      hasPoiSelectionOverride:
+        currentState.key === placeKey
+          ? currentState.hasPoiSelectionOverride
+          : false,
     }))
   }
 
@@ -268,6 +305,10 @@ export default function MapPoiSheet({
         currentState.key === placeKey
           ? currentState.selectedPoiId
           : selectedPoiFromPlace?.id ?? null,
+      hasPoiSelectionOverride:
+        currentState.key === placeKey
+          ? currentState.hasPoiSelectionOverride
+          : false,
     }))
   }
 
@@ -306,6 +347,7 @@ export default function MapPoiSheet({
           showPOIs={showPOIs}
           onTogglePOIs={handleTogglePOIs}
           selectedPoiId={selectedPoiId}
+          selectedPoiName={selectedPoi?.name ?? null}
           onSelectPoi={handleSelectPoi}
           reviewSummary={demoReviewSummary}
           reviews={demoReviews}

--- a/src/components/Map/MapPoiSheet.jsx
+++ b/src/components/Map/MapPoiSheet.jsx
@@ -260,7 +260,11 @@ export default function MapPoiSheet({
     setPoiPanelState((currentState) => {
       const nextPoiId = poi.id ?? null
       const currentPoiId =
-        currentState.key === placeKey ? currentState.selectedPoiId : null
+        currentState.key === placeKey
+          ? currentState.hasPoiSelectionOverride
+            ? currentState.selectedPoiId
+            : selectedPoiFromPlace?.id ?? null
+          : selectedPoiFromPlace?.id ?? null
       const isSamePoiSelected =
         currentPoiId != null &&
         nextPoiId != null &&

--- a/src/components/Search/SearchAutocompleteList.jsx
+++ b/src/components/Search/SearchAutocompleteList.jsx
@@ -22,7 +22,7 @@ export default function SearchAutocompleteList({
   onClearRecentKeywords,
   onSelectRecentKeyword,
 }) {
-  const hasRecentKeywords = recentKeywords.length > 0
+  const hasRecentKeywords = recentKeywords.length > 0 && items.length === 0
   const hasAutocompleteItems = items.length > 0
 
   if (!hasRecentKeywords && !hasAutocompleteItems) {

--- a/src/components/Search/SearchAutocompleteList.jsx
+++ b/src/components/Search/SearchAutocompleteList.jsx
@@ -1,30 +1,88 @@
-import { IoSearchOutline } from 'react-icons/io5'
+import { IoCloseOutline, IoSearchOutline, IoTimeOutline } from 'react-icons/io5'
 import {
   AutocompleteSection,
+  KeywordAction,
   KeywordIcon,
   KeywordItem,
   KeywordList,
+  KeywordRow,
+  KeywordRowButton,
+  KeywordText,
+  SectionAction,
+  SectionGroup,
+  SectionHeader,
   SectionTitle,
 } from './SearchAutocompleteList.styles'
 
-export default function SearchAutocompleteList({ items = [], onSelect }) {
+export default function SearchAutocompleteList({
+  recentKeywords = [],
+  items = [],
+  onSelect,
+  onRemoveRecentKeyword,
+  onClearRecentKeywords,
+  onSelectRecentKeyword,
+}) {
+  const hasRecentKeywords = recentKeywords.length > 0
+  const hasAutocompleteItems = items.length > 0
+
+  if (!hasRecentKeywords && !hasAutocompleteItems) {
+    return null
+  }
+
   return (
     <AutocompleteSection>
-      <SectionTitle>자동완성</SectionTitle>
-      <KeywordList>
-        {items.map((item, index) => (
-          <KeywordItem
-            key={item.id ?? `${item.title}-${index}`}
-            type="button"
-            onClick={() => onSelect?.(item)}
-          >
-            <KeywordIcon>
-              <IoSearchOutline size={14} />
-            </KeywordIcon>
-            <span>{item.title}</span>
-          </KeywordItem>
-        ))}
-      </KeywordList>
+      {hasRecentKeywords ? (
+        <SectionGroup>
+          <SectionHeader>
+            <SectionTitle>최근 검색어</SectionTitle>
+            <SectionAction type="button" onClick={() => onClearRecentKeywords?.()}>
+              전체 삭제
+            </SectionAction>
+          </SectionHeader>
+          <KeywordList>
+            {recentKeywords.map((keyword, index) => (
+              <KeywordRow key={`${keyword}-${index}`}>
+                <KeywordRowButton
+                  type="button"
+                  onClick={() => onSelectRecentKeyword?.(keyword)}
+                >
+                  <KeywordIcon>
+                    <IoTimeOutline size={14} />
+                  </KeywordIcon>
+                  <KeywordText>{keyword}</KeywordText>
+                </KeywordRowButton>
+                <KeywordAction
+                  type="button"
+                  aria-label={`${keyword} 삭제`}
+                  onClick={() => onRemoveRecentKeyword?.(keyword)}
+                >
+                  <IoCloseOutline size={16} />
+                </KeywordAction>
+              </KeywordRow>
+            ))}
+          </KeywordList>
+        </SectionGroup>
+      ) : null}
+
+      {hasAutocompleteItems ? (
+        <SectionGroup>
+          <SectionTitle>자동완성</SectionTitle>
+          <KeywordList>
+            {items.map((item, index) => (
+              <KeywordItem
+                key={item.id ?? `${item.title}-${index}`}
+                type="button"
+                onClick={() => onSelect?.(item)}
+              >
+                <KeywordIcon>
+                  <IoSearchOutline size={14} />
+                </KeywordIcon>
+                <span>{item.title}</span>
+              </KeywordItem>
+            ))}
+          </KeywordList>
+        </SectionGroup>
+      ) : null}
     </AutocompleteSection>
   )
 }

--- a/src/components/Search/SearchAutocompleteList.styles.js
+++ b/src/components/Search/SearchAutocompleteList.styles.js
@@ -4,6 +4,21 @@ export const AutocompleteSection = styled.section`
   width: 100%;
   padding: var(--space-12) var(--space-16) 0;
   border-top: var(--size-1) solid var(--gray-200);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-20);
+`
+
+export const SectionGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+`
+
+export const SectionHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-12);
 `
 
 export const SectionTitle = styled.h2`
@@ -15,9 +30,38 @@ export const SectionTitle = styled.h2`
   line-height: var(--line-20);
 `
 
+export const SectionAction = styled.button`
+  border: none;
+  background: transparent;
+  padding: 0;
+  color: var(--gray-500);
+  font-family: var(--font-sans);
+  font-size: var(--text-13);
+  font-weight: 500;
+  line-height: var(--line-20);
+  cursor: pointer;
+
+  &:hover {
+    color: var(--black-950);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--blue-600);
+    outline-offset: 2px;
+    border-radius: var(--radius-4);
+  }
+`
+
 export const KeywordList = styled.div`
   display: flex;
   flex-direction: column;
+  gap: var(--space-8);
+`
+
+export const KeywordRow = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
   gap: var(--space-8);
 `
 
@@ -48,6 +92,34 @@ export const KeywordItem = styled.button`
   }
 `
 
+export const KeywordRowButton = styled(KeywordItem)`
+  flex: 1;
+`
+
+export const KeywordAction = styled.button`
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--gray-400);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--surface-50);
+    color: var(--black-950);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--blue-600);
+    outline-offset: 2px;
+  }
+`
+
 export const KeywordIcon = styled.span`
   width: var(--size-16);
   height: var(--size-16);
@@ -56,4 +128,9 @@ export const KeywordIcon = styled.span`
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
+`
+
+export const KeywordText = styled.span`
+  flex: 1;
+  min-width: 0;
 `

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -13,10 +13,14 @@ export default function SearchPage() {
     isLoading,
     hasSearchError,
     searchStateMessage,
+    recentKeywords,
     autocompleteItems,
     resultItems,
     handleChangeKeyword,
     handleSelectAutocomplete,
+    handleRemoveRecentKeyword,
+    handleClearRecentKeywords,
+    handleSelectRecentKeyword,
     handleSelectResult,
     runSearch,
   } = useSearchPageController()
@@ -39,8 +43,12 @@ export default function SearchPage() {
       <section className="search-page__content">
         {!isResultMode ? (
           <SearchAutocompleteList
+            recentKeywords={recentKeywords}
             items={autocompleteItems}
             onSelect={handleSelectAutocomplete}
+            onRemoveRecentKeyword={handleRemoveRecentKeyword}
+            onClearRecentKeywords={handleClearRecentKeywords}
+            onSelectRecentKeyword={handleSelectRecentKeyword}
           />
         ) : null}
 

--- a/src/pages/SearchPage/useSearchPageController.js
+++ b/src/pages/SearchPage/useSearchPageController.js
@@ -24,6 +24,8 @@ const HANGUL_JAMO_ONLY_REGEX = /^[ㄱ-ㅎㅏ-ㅣ]+$/
 const GEOLOCATION_UNAVAILABLE_MESSAGE = '현재 위치 정보를 사용할 수 없습니다.'
 const GEOLOCATION_REQUIRED_MESSAGE = '현재 위치를 확인한 뒤 다시 검색해 주세요.'
 const SEARCH_FAILED_MESSAGE = '검색 결과를 불러오지 못했습니다.'
+const RECENT_SEARCH_STORAGE_KEY = 'recent-search-keywords'
+const MAX_RECENT_SEARCHES = 8
 
 function isInvalidIntermediateKeyword(keyword) {
   return HANGUL_JAMO_ONLY_REGEX.test(keyword)
@@ -90,6 +92,93 @@ function getPlaceCenter(place, fallbackCenter = null) {
   return fallbackCenter
 }
 
+function loadRecentSearchKeywords() {
+  if (typeof window === 'undefined') {
+    return []
+  }
+
+  try {
+    const savedKeywords = window.localStorage.getItem(RECENT_SEARCH_STORAGE_KEY)
+
+    if (!savedKeywords) {
+      return []
+    }
+
+    const parsedKeywords = JSON.parse(savedKeywords)
+
+    if (!Array.isArray(parsedKeywords)) {
+      return []
+    }
+
+    return parsedKeywords.filter(
+      (keyword) => typeof keyword === 'string' && keyword.trim(),
+    )
+  } catch {
+    return []
+  }
+}
+
+function saveRecentSearchKeyword(rawKeyword, currentKeywords) {
+  const trimmedKeyword = rawKeyword.trim()
+
+  if (!trimmedKeyword || typeof window === 'undefined') {
+    return currentKeywords
+  }
+
+  const normalizedKeyword = normalizeText(trimmedKeyword)
+  const nextKeywords = [
+    trimmedKeyword,
+    ...currentKeywords.filter(
+      (keyword) => normalizeText(keyword) !== normalizedKeyword,
+    ),
+  ].slice(0, MAX_RECENT_SEARCHES)
+
+  try {
+    window.localStorage.setItem(
+      RECENT_SEARCH_STORAGE_KEY,
+      JSON.stringify(nextKeywords),
+    )
+  } catch {
+    return currentKeywords
+  }
+
+  return nextKeywords
+}
+
+function removeRecentSearchKeyword(targetKeyword, currentKeywords) {
+  const normalizedTargetKeyword = normalizeText(targetKeyword)
+  const nextKeywords = currentKeywords.filter(
+    (keyword) => normalizeText(keyword) !== normalizedTargetKeyword,
+  )
+
+  if (typeof window !== 'undefined') {
+    try {
+      window.localStorage.setItem(
+        RECENT_SEARCH_STORAGE_KEY,
+        JSON.stringify(nextKeywords),
+      )
+    } catch {
+      return currentKeywords
+    }
+  }
+
+  return nextKeywords
+}
+
+function clearRecentSearchKeywords() {
+  if (typeof window === 'undefined') {
+    return []
+  }
+
+  try {
+    window.localStorage.removeItem(RECENT_SEARCH_STORAGE_KEY)
+  } catch {
+    return loadRecentSearchKeywords()
+  }
+
+  return []
+}
+
 export default function useSearchPageController() {
   const location = useLocation()
   const navigate = useNavigate()
@@ -112,6 +201,7 @@ export default function useSearchPageController() {
     supportsGeolocation ? '' : GEOLOCATION_UNAVAILABLE_MESSAGE,
   )
   const [searchCenter, setSearchCenter] = useState(null)
+  const [recentKeywords, setRecentKeywords] = useState(() => loadRecentSearchKeywords())
   const [autocompleteItems, setAutocompleteItems] = useState([])
   const [resultItems, setResultItems] = useState([])
   const searchTimerRef = useRef(null)
@@ -215,6 +305,7 @@ export default function useSearchPageController() {
 
   const runSearch = (rawKeyword) => {
     const normalized = normalizeText(rawKeyword)
+    const trimmedKeyword = rawKeyword.trim()
 
     if (!normalized || isInvalidIntermediateKeyword(normalized)) {
       invalidatePendingSearch()
@@ -226,6 +317,9 @@ export default function useSearchPageController() {
       return
     }
 
+    setRecentKeywords((currentKeywords) =>
+      saveRecentSearchKeyword(trimmedKeyword, currentKeywords),
+    )
     setIsResultMode(true)
     setIsLoading(true)
     setHasSearchError(false)
@@ -276,6 +370,21 @@ export default function useSearchPageController() {
     runSearch(selectedItem.title)
   }
 
+  const handleSelectRecentKeyword = (selectedKeyword) => {
+    setKeyword(selectedKeyword)
+    runSearch(selectedKeyword)
+  }
+
+  const handleRemoveRecentKeyword = (targetKeyword) => {
+    setRecentKeywords((currentKeywords) =>
+      removeRecentSearchKeyword(targetKeyword, currentKeywords),
+    )
+  }
+
+  const handleClearRecentKeywords = () => {
+    setRecentKeywords(clearRecentSearchKeywords())
+  }
+
   const handleSelectResult = (selectedPlace) => {
     const selectedMapCenter = getPlaceCenter(selectedPlace, mapCenter)
 
@@ -315,10 +424,14 @@ export default function useSearchPageController() {
     isLoading,
     hasSearchError,
     searchStateMessage,
+    recentKeywords,
     autocompleteItems,
     resultItems,
     handleChangeKeyword,
     handleSelectAutocomplete,
+    handleRemoveRecentKeyword,
+    handleClearRecentKeywords,
+    handleSelectRecentKeyword,
     handleSelectResult,
     runSearch,
   }


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closed #55 

## 📝작업 내용
- POI 재클릭 시 선택 해제 및 건물 기준 경로 설정 반영

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 하단 액션 버튼의 텍스트가 선택된 관심지점 이름으로 동적으로 표시됩니다(선택 없을 땐 기존 기본 문구 유지).

* **Improvements**
  * 관심지점 선택 상태 관리가 개선되어 선택 토글, 닫기 시 상태 초기화 등 더 직관적이고 안정적으로 동작합니다.
  * 동일 패널/동일 선택 처리 로직이 개선되어 불필요한 변경이 줄어듭니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->