### PR TITLE
[feat] 실내->실내 길찾기 구현(#61)

### DIFF
--- a/src/apis/utils/navigationRouteMapper.js
+++ b/src/apis/utils/navigationRouteMapper.js
@@ -108,7 +108,7 @@ function buildExitInstruction(legs, indoorMeta) {
     getCleanText(indoorMeta?.entranceName) ??
     getExitLegEndpointName(legs)
 
-  return entranceName ? `${entranceName}로 나가기` : null
+  return entranceName ? `${entranceName}으로 나가기` : null
 }
 
 function getExitLegEndpointName(legs) {

--- a/src/components/Map/floorplan/floorplanVectorMap.js
+++ b/src/components/Map/floorplan/floorplanVectorMap.js
@@ -1,5 +1,6 @@
 import escalatorIcon from '../../../assets/icons/escalator.svg'
 import elevatorIcon from '../../../assets/icons/elevator.svg'
+import stairsIcon from '../../../assets/icons/stairs.svg'
 import {
   clamp,
   geoJsonToPath,
@@ -151,6 +152,14 @@ function resolvePoiIcon(poi) {
     searchText.includes('에스칼레이터')
   ) {
     return escalatorIcon
+  }
+
+  if (
+    searchText.includes('stair') ||
+    searchText.includes('stairs') ||
+    searchText.includes('계단')
+  ) {
+    return stairsIcon
   }
 
   return null

--- a/src/components/NavigationGuidance/NavigationStepIcon.jsx
+++ b/src/components/NavigationGuidance/NavigationStepIcon.jsx
@@ -13,7 +13,7 @@ import {
   IconImage,
   PlainStepIcon,
 } from './NavigationStepIcon.styles'
-import { isArrivalStep } from '../../utils/navigationStepTypes'
+import { isArrivalStep, isIndoorStep } from '../../utils/navigationStepTypes'
 
 export default function NavigationStepIcon({ step, variant = 'plain', tone: toneOverride }) {
   const safeStep = step && typeof step === 'object' ? step : {}
@@ -69,11 +69,6 @@ function getStepIcon(step = {}) {
   return <IconImage src={src} alt="" aria-hidden="true" />
 }
 
-function isIndoorStep(step = {}) {
-  const mode = String(step.mode ?? '').toUpperCase()
-  return step.type === 'indoor' || mode === 'INDOOR'
-}
-
 function isBuildingArrivalStep(step = {}) {
   const mode = String(step.mode ?? '').toUpperCase()
   return mode === 'BUILDING' || step.stepType === 'BUILDING_ARRIVAL'
@@ -84,7 +79,7 @@ function isBuildingExitStep(step = {}, normalizedText = '') {
   return (
     normalizedText.includes('건물 출구') ||
     normalizedText.includes('로 나가기') ||
-    (mode === 'INDOOR' && normalizedText.includes('나가기'))
+    (isIndoorStep(step) && mode !== 'BUILDING' && normalizedText.includes('나가기'))
   )
 }
 

--- a/src/components/NavigationGuidance/NavigationStepIcon.jsx
+++ b/src/components/NavigationGuidance/NavigationStepIcon.jsx
@@ -3,6 +3,7 @@ import crosswalkIcon from '../../assets/icons/D_crosswalk.svg'
 import doorIcon from '../../assets/icons/door.svg'
 import hyphenIcon from '../../assets/icons/D_hyphen.svg'
 import elevatorIcon from '../../assets/icons/elevator.svg'
+import escalatorIcon from '../../assets/icons/escalator.svg'
 import leftIcon from '../../assets/icons/leftSign.svg'
 import locateIcon from '../../assets/icons/MyLocate.svg'
 import rightIcon from '../../assets/icons/rightSign.svg'
@@ -40,7 +41,9 @@ function getStepIcon(step = {}) {
     src = locateIcon
   } else if (isElevatorVerticalMove(normalizedText)) {
     src = elevatorIcon
-  } else if (isStairVerticalMove(normalizedText) || isEscalatorVerticalMove(normalizedText)) {
+  } else if (isEscalatorVerticalMove(normalizedText)) {
+    src = escalatorIcon
+  } else if (isStairVerticalMove(normalizedText)) {
     src = stairIcon
   } else if (normalizedText.includes('횡단보도') || normalizedText.includes('crosswalk')) {
     src = crosswalkIcon

--- a/src/components/NavigationGuidance/TransitTurnByTurnList.jsx
+++ b/src/components/NavigationGuidance/TransitTurnByTurnList.jsx
@@ -229,8 +229,8 @@ function buildBuildingArrivalLeg(rawLegs, indoorBuildingName, fallbackDestinatio
   const indoorLegIndex = findFirstIndoorLegIndex(rawLegs)
   const indoorLeg = indoorLegIndex >= 0 ? rawLegs[indoorLegIndex] : null
   const placeName =
-    fallbackDestination ??
     indoorLeg?.startName ??
+    fallbackDestination ??
     '건물'
   const name = buildBuildingArrivalName(indoorBuildingName, placeName)
 

--- a/src/components/NavigationGuidance/TurnByTurnList.jsx
+++ b/src/components/NavigationGuidance/TurnByTurnList.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import CommonHeader from '../CommonHeader/CommonHeader'
 import { isDistanceSummaryInstruction } from '../../utils/navigationStepFilters'
+import { isIndoorStep } from '../../utils/navigationStepTypes'
 import DurationWithIndoorSuffix from './DurationWithIndoorSuffix'
 import TurnByTurnStepItem from './TurnByTurnStepItem'
 import {
@@ -156,12 +157,6 @@ function getRouteSectionDividerLabel(visibleSteps, index) {
   }
 
   return null
-}
-
-function isIndoorStep(step = {}) {
-  const safeStep = step && typeof step === 'object' ? step : {}
-  const mode = String(safeStep.mode ?? '').toUpperCase()
-  return safeStep.type === 'indoor' || mode === 'INDOOR' || Boolean(safeStep.floorId)
 }
 
 function shouldShowStep(step = {}) {

--- a/src/pages/RoutingPage/useRoutingController.js
+++ b/src/pages/RoutingPage/useRoutingController.js
@@ -9,6 +9,7 @@ import {
   toNavigationPlace,
   toNavigationRequestInput,
 } from '../../utils/map/navigationPlaceMapper'
+import { isIndoorStep } from '../../utils/navigationStepTypes'
 
 export default function useRoutingController({
   initialCurrentNav = 'map',
@@ -67,10 +68,7 @@ export default function useRoutingController({
     effectiveGuidanceSteps[effectiveBoundedGuidanceStepIndex] ??
     effectiveGuidanceSteps[0] ??
     null
-  const isIndoorGuidanceStep =
-    !!effectiveActiveGuidanceStep?.floorId ||
-    effectiveActiveGuidanceStep?.type === 'indoor' ||
-    effectiveActiveGuidanceStep?.mode === 'INDOOR'
+  const isIndoorGuidanceStep = isIndoorStep(effectiveActiveGuidanceStep)
 
   const requestRoute = async ({
     origin = routeOrigin,

--- a/src/utils/navigationStepTypes.js
+++ b/src/utils/navigationStepTypes.js
@@ -5,3 +5,16 @@ export const STEP_TYPE = {
 export function isArrivalStep(step = {}) {
   return Boolean(step?.arrival) || step?.stepType === STEP_TYPE.ARRIVAL
 }
+
+export function isIndoorStep(step = {}) {
+  const safeStep = step && typeof step === 'object' ? step : {}
+  const mode = String(safeStep.mode ?? '').toUpperCase()
+
+  return (
+    safeStep.type === 'indoor' ||
+    safeStep.type === 'campus' ||
+    mode === 'INDOOR' ||
+    mode === 'CAMPUS' ||
+    Boolean(safeStep.floorId)
+  )
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> Closed #61 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **리팩토링**
  * 실내/실외 단계 판별 로직을 통합해 안내 일관성 및 중복 제거

* **개선**
  * 수직 이동(계단/에스컬레이터/엘리베이터) 아이콘 선택 로직 개선으로 더 정확한 아이콘 표시
  * 건물 출구 안내 문구 조사 표기 개선(나가기 표현 조정)
  * 도착지명 우선순위 조정으로 건물 도착 안내의 표시명 개선

* **신규**
  * POI 이름/태그 인식에 계단 키워드 추가로 계단 POI에 전용 아이콘 표시
<!-- end of auto-generated comment: release notes by coderabbit.ai -->